### PR TITLE
Docs: Fix edit link

### DIFF
--- a/docs/samplesheets/samplesheetToList.md
+++ b/docs/samplesheets/samplesheetToList.md
@@ -38,7 +38,7 @@ Channel.fromList(samplesheetToList("path/to/samplesheet", "path/to/json/schema")
 
     This will mimic the `fromSamplesheet` channel factory as it was in [nf-validation](https://github.com/nextflow-io/nf-validation).
 
-### Use as a channel oprator
+### Use as a channel operator
 
 The function can be used with the `.flatMap` channel operator to create a channel from samplesheets that are already in a channel:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: nf-schema
 repo_name: nextflow-io/nf-schema
 repo_url: https://github.com/nextflow-io/nf-schema
 site_url: https://nextflow-io.github.io/nf-schema/latest/
-edit_uri: edit/main/docs/
+edit_uri: edit/master/docs/
 
 nav:
   - Home:


### PR DESCRIPTION
`master`, not `main`