### PR TITLE
Improvement/help messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,20 @@
 ## New features
 
 1. The plugin now fully supports nested parameters!
+2. Added a config option `validation.parametersSchema` which can be used to set the parameters JSON schema in a config file. The default is `nextflow_schema.json`
 
 ## Help message changes
 
 1. The use of the `paramsHelp()` function has now been deprecated in favor of a new built-in help message functionality. `paramsHelp()` has been updated to use the reworked help message creator. If you still want to use `paramsHelp()` for some reason in your pipeline, please add the `hideWarning:true` option to it to make sure the deprecation warning will not be shown.
 2. Added new configuration values to support the new help message functionality:
-    - `validation.help.enabled`: Enables the checker for the help message parameters. The plugin will automatically show the help message when one of these parameters have been given and exit the pipeline. Default = `false`
-    - `validation.help.shortParameter`: The parameter to use for the compact help message. This help message will only contain top level parameters. Default = `help`
-    - `validation.help.fullParameter`: The parameter to use for the expanded help message. This help message will show all parameters no matter how deeply nested they are. Default = `helpFull`
-    - `validation.help.showHiddenParameter`: The parameter to use to also show all parameters with the `hidden: true` keyword in the schema. Default = `showHidden`
-    - `validation.help.showHidden`: Set this to `true` to show hidden parameters by default. This configuration option is overwritten by the value supplied to the parameter in `validation.help.showHiddenParameter`. Default = `false`
-    - `validation.help.beforeText`: Some custom text to add before the help message.
-    - `validation.help.afterText`: Some custom text to add after the help message.
-    - `validation.help.command`: An example command to add to the top of the help message
+   - `validation.help.enabled`: Enables the checker for the help message parameters. The plugin will automatically show the help message when one of these parameters have been given and exit the pipeline. Default = `false`
+   - `validation.help.shortParameter`: The parameter to use for the compact help message. This help message will only contain top level parameters. Default = `help`
+   - `validation.help.fullParameter`: The parameter to use for the expanded help message. This help message will show all parameters no matter how deeply nested they are. Default = `helpFull`
+   - `validation.help.showHiddenParameter`: The parameter to use to also show all parameters with the `hidden: true` keyword in the schema. Default = `showHidden`
+   - `validation.help.showHidden`: Set this to `true` to show hidden parameters by default. This configuration option is overwritten by the value supplied to the parameter in `validation.help.showHiddenParameter`. Default = `false`
+   - `validation.help.beforeText`: Some custom text to add before the help message.
+   - `validation.help.afterText`: Some custom text to add after the help message.
+   - `validation.help.command`: An example command to add to the top of the help message
 3. Added support for nested parameters to the help message. A detailed help message using `--help <parameter>` will now also contain all nested parameters. The parameter supplied to `--help` can be a nested parameter too (e.g. `--help top_parameter.nested_parameter.deeper_parameter`)
 4. The help message now won't show empty parameter groups.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@
 
 1. The plugin now fully supports nested parameters!
 
+## Help message changes
+
+1. The use of the `paramsHelp()` function has now been deprecated in favor of a new built-in help message functionality. `paramsHelp()` has been updated to use the reworked help message creator. If you still want to use `paramsHelp()` for some reason in your pipeline, please add the `hideWarning:true` option to it to make sure the deprecation warning will not be shown.
+2. Added new configuration values to support the new help message functionality:
+    - `validation.help.enabled`: Enables the checker for the help message parameters. The plugin will automatically show the help message when one of these parameters have been given and exit the pipeline. Default = `false`
+    - `validation.help.shortParameter`: The parameter to use for the compact help message. This help message will only contain top level parameters. Default = `help`
+    - `validation.help.fullParameter`: The parameter to use for the expanded help message. This help message will show all parameters no matter how deeply nested they are. Default = `helpFull`
+    - `validation.help.showHiddenParameter`: The parameter to use to also show all parameters with the `hidden: true` keyword in the schema. Default = `showHidden`
+    - `validation.help.showHidden`: Set this to `true` to show hidden parameters by default. This configuration option is overwritten by the value supplied to the parameter in `validation.help.showHiddenParameter`. Default = `false`
+    - `validation.help.beforeText`: Some custom text to add before the help message.
+    - `validation.help.afterText`: Some custom text to add after the help message.
+    - `validation.help.command`: An example command to add to the top of the help message
+3. Added support for nested parameters to the help message. A detailed help message using `--help <parameter>` will now also contain all nested parameters. The parameter supplied to `--help` can be a nested parameter too (e.g. `--help top_parameter.nested_parameter.deeper_parameter`)
+4. The help message now won't show empty parameter groups.
+
 ## JSON schema fixes
 
 1. The `defs` keyword is now deprecated in favor of the `$defs` keyword. This to follow the JSON schema guidelines. We will continue supporting `defs` for backwards compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Version 2.1.0
 
+## Breaking changes
+
+1. The minimum supported Nextflow version is now `23.10.0` instead of `22.10.0`
+
 ## New features
 
 1. The plugin now fully supports nested parameters!

--- a/buildSrc/src/main/groovy/io.nextflow.groovy-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.nextflow.groovy-common-conventions.gradle
@@ -14,7 +14,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(19)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-nextflowVersion = 22.10.0
+nextflowVersion = 23.10.0
 groovyVersion = 3.0.14

--- a/plugins/nf-schema/build.gradle
+++ b/plugins/nf-schema/build.gradle
@@ -79,5 +79,26 @@ dependencies {
 
 // use JUnit 5 platform
 test {
-    useJUnitPlatform()
+    useJUnitPlatform() 
+}
+
+tasks.withType(Test) {
+    jvmArgs ([
+            '--add-opens=java.base/java.lang=ALL-UNNAMED',
+            '--add-opens=java.base/java.io=ALL-UNNAMED',
+            '--add-opens=java.base/java.nio=ALL-UNNAMED',
+            '--add-opens=java.base/java.nio.file.spi=ALL-UNNAMED',
+            '--add-opens=java.base/java.net=ALL-UNNAMED',
+            '--add-opens=java.base/java.util=ALL-UNNAMED',
+            '--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED',
+            '--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED',
+            '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+            '--add-opens=java.base/sun.nio.fs=ALL-UNNAMED',
+            '--add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED',
+            '--add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED',
+            '--add-opens=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED',
+            '--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED',
+            '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED',
+            '--add-opens=java.base/jdk.internal.vm=ALL-UNNAMED',
+    ])
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
@@ -67,17 +67,17 @@ class HelpMessage {
     public String getBeforeText() {
         def String beforeText = config.help.beforeText
         if (config.help.command) {
-            beforeText += "Typical pipeline command:\n"
-            beforeText += "  ${colors.cyan}${config.help.command}${colors.reset}\n"
+            beforeText += "Typical pipeline command:\n\n"
+            beforeText += "  ${colors.cyan}${config.help.command}${colors.reset}\n\n"
         }
     }
 
     public String getAfterText() {
         def String afterText = ""
         if (hiddenParametersCount > 0) {
-            afterText += " ${colors.dim}!! Hiding ${hiddenParametersCount} param(s), use the `--${config.help.showHiddenParameter}` parameter to show them !!${colors.reset}"
+            afterText += " ${colors.dim}!! Hiding ${hiddenParametersCount} param(s), use the `--${config.help.showHiddenParameter}` parameter to show them !!${colors.reset}\n"
         }
-        afterText += "-${colors.dim}----------------------------------------------------${colors.reset}-"
+        afterText += "-${colors.dim}----------------------------------------------------${colors.reset}-\n"
         afterText += config.help.afterText
     }
 

--- a/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
@@ -70,6 +70,7 @@ class HelpMessage {
             beforeText += "Typical pipeline command:\n\n"
             beforeText += "  ${colors.cyan}${config.help.command}${colors.reset}\n\n"
         }
+        return beforeText
     }
 
     public String getAfterText() {
@@ -79,6 +80,7 @@ class HelpMessage {
         }
         afterText += "-${colors.dim}----------------------------------------------------${colors.reset}-\n"
         afterText += config.help.afterText
+        return afterText
     }
 
     //
@@ -229,6 +231,24 @@ class HelpMessage {
             "type": "boolean",
             "description": "Show all hidden parameters in the help message. This needs to be used in combination with `--${config.help.shortParameter}` or `--${config.help.fullParameter}`."
         ]
+    }
+
+    //
+    // Wrap too long text
+    //
+    private String wrapText(String text) {
+        def List olines = []
+        def String oline = ""
+        text.split(" ").each() { wrd ->
+            if ((oline.size() + wrd.size()) <= terminalLength) {
+                oline += wrd + " "
+            } else {
+                olines += oline
+                oline = wrd + " "
+            }
+        }
+        olines += oline
+        return olines.join("\n")
     }
 
 

--- a/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
@@ -73,7 +73,7 @@ class HelpMessage {
 
     public printAfterText() {
         if (hiddenParametersCount > 0) {
-            log.info(" ${colors.dim}!! Hiding ${hiddenParametersCount} param(s), use the `validation.showHiddenParams` config value to show them !!${colors.reset}")
+            log.info(" ${colors.dim}!! Hiding ${hiddenParametersCount} param(s), use the `--${config.help.showHiddenParameter}` parameter to show them !!${colors.reset}")
         }
         log.info(config.help.afterText)
     }
@@ -138,7 +138,7 @@ class HelpMessage {
     }
 
     private Map<String,Map> removeHidden(Map<String,Map> map) {
-        if (config.help.showHiddenParams) {
+        if (config.help.showHidden) {
             return map
         }
         def Map<String,Map> returnMap = [:]
@@ -162,10 +162,6 @@ class HelpMessage {
         def List helpMessage = []
         for (String paramName in params.keySet()) {
             def Map paramOptions = params.get(paramName) as Map 
-            if (paramOptions.hidden && !config.showHiddenParams) {
-                hiddenParametersCount += 1
-                continue
-            }
             def String type = '[' + paramOptions.type + ']'
             def String enumsString = ""
             if (paramOptions.enum != null) {

--- a/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
@@ -62,6 +62,10 @@ class HelpMessage {
 
     public printBeforeText() {
         log.info(config.help.beforeText)
+        if (config.help.command) {
+            log.info("Typical pipeline command:\n")
+            log.info("  ${colors.cyan}${config.help.command}${colors.reset}\n")
+        }
     }
 
     public printAfterText() {

--- a/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
@@ -1,0 +1,157 @@
+package nextflow.validation
+
+import groovy.util.logging.Slf4j
+
+import java.nio.file.Path
+
+import nextflow.Session
+
+/**
+ * This class contains methods to write a help message
+ *
+ * @author : nvnieuwk <nicolas.vannieuwkerke@ugent.be>
+ *
+ */
+
+@Slf4j
+class HelpMessage {
+
+    private final ValidationConfig config
+    private final Map colors
+    private Integer hiddenParametersCount = 0
+    private Map<String,Map> paramsMap
+    private Integer maxChars
+
+    // The length of the terminal
+    private Integer terminalLength = System.getenv("COLUMNS")?.toInteger() ?: 100
+
+    HelpMessage(ValidationConfig config, Session session) {
+        config = config
+        colors = Utils.logColours(config.monochromeLogs)
+        paramsMap = Utils.paramsLoad( Path.of(Utils.getSchemaPath(session.baseDir.toString(), config.parametersSchema)) )
+        maxChars = Utils.paramsMaxChars(paramsMap) + 1
+    }
+
+    public printShortHelpMessage(String param) {
+        if (param) {
+            def List<String> paramNames = param.tokenize(".") as List<String>
+            def Map paramOptions = [:]
+            for (group in paramsMap.keySet()) {
+                def Map groupParams = paramsMap.get(group) as Map // This gets the parameters of that particular group
+                if (groupParams.containsKey(paramNames[0])) {
+                    paramOptions = groupParams.get(paramNames[0]) as Map 
+                }
+            }
+            if (paramNames.size() > 1) {
+                paramNames.remove(0)
+                paramNames.each {
+                    paramOptions = (Map) paramOptions?.properties?[it] ?: [:]
+                }
+            }
+            if (!paramOptions) {
+                throw new Exception("Specified param '${paramName}' does not exist in JSON schema.")
+            }
+            log.info(getDetailedHelpString(param, paramOptions, colors))
+        }
+        log.info("Short help message")
+    }
+
+    public printFullHelpMessage() {
+        log.info("Full help message")
+    }
+
+    private Map<String, Map> getHelpMap() {
+        helpMap = [:]
+        
+        return helpMap
+    }
+
+    //
+    // Get a detailed help string from one parameter
+    //
+    private String getDetailedHelpString(String paramName, Map paramOptions, Map colors) {
+        def String helpMessage = "--" + paramName + '\n'
+        for (option in paramOptions) {
+            def String key = option.key
+            if (key == "fa_icon" || (key == "type" && option.value == "object")) {
+                continue
+            }
+            if (key == "properties") {
+                def Map subParamsOptions = [:]
+                flattenNestedSchemaMap(option.value as Map).each { String subParam, Map value ->
+                    subParamsOptions.put("${paramName}.${subParam}" as String, value)
+                }
+                def Integer maxChars = Utils.paramsMaxChars(subParamsOptions, true) + 1
+                def String subParamsHelpString = getHelpList(subParamsOptions, colors, maxChars, paramName)
+                    .collect {
+                        "      --" + it[4..it.length()-1]
+                    }
+                    .join("\n")
+                helpMessage += "    " + colors.dim + "options".padRight(11) + ": " + colors.reset + "\n" + subParamsHelpString + "\n"
+                continue
+            }
+            def String value = option.value
+            if (value.length() > terminalLength) {
+                value = wrapText(value)
+            }
+            helpMessage += "    " + colors.dim + key.padRight(11) + ": " + colors.reset + value + '\n'
+        }
+        return helpMessage
+    }
+
+    //
+    // Get help text in string format
+    //
+    private List<String> getHelpList(Map<String,Map> params, Map colors, Integer maxChars, String parentParameter = "") {
+        def List helpMessage = []
+        for (String paramName in params.keySet()) {
+            def Map paramOptions = params.get(paramName) as Map 
+            if (paramOptions.hidden && !config.showHiddenParams) {
+                hiddenParametersCount += 1
+                continue
+            }
+            def String type = '[' + paramOptions.type + ']'
+            def String enumsString = ""
+            if (paramOptions.enum != null) {
+                def List enums = (List) paramOptions.enum
+                def String chopEnums = enums.join(", ")
+                if(chopEnums.length() > terminalLength){
+                    chopEnums = chopEnums.substring(0, terminalLength-5)
+                    chopEnums = chopEnums.substring(0, chopEnums.lastIndexOf(",")) + ", ..."
+                }
+                enumsString = " (accepted: " + chopEnums + ") "
+            }
+            def String description = paramOptions.description ? paramOptions.description as String + " " : ""
+            def defaultValue = paramOptions.default != null ? "[default: " + paramOptions.default.toString() + "] " : ''
+            def String nestedParamName = parentParameter ? parentParameter + "." + paramName : paramName
+            def String nestedString = paramOptions.properties ? "(This parameter has sub-parameters. Use '--help ${nestedParamName}' to see all sub-parameters) " : ""
+            def descriptionDefault = description + colors.dim + enumsString + defaultValue + colors.reset + nestedString
+            // Wrap long description texts
+            // Loosely based on https://dzone.com/articles/groovy-plain-text-word-wrap
+            if (descriptionDefault.length() > terminalLength){
+                descriptionDefault = wrapText(descriptionDefault)
+            }
+            helpMessage.add("  --" +  paramName.padRight(maxChars) + colors.dim + type.padRight(10) + colors.reset + descriptionDefault)
+        }
+        return helpMessage
+    }
+
+    //
+    // Flattens the schema params map so all nested parameters are shown as their full name
+    //
+    private Map<String,Map> flattenNestedSchemaMap(Map params) {
+        def Map returnMap = [:]
+        params.each { String key, Map value ->
+            if (value.containsKey("properties")) {
+                def flattenedMap = flattenNestedSchemaMap(value.properties)
+                flattenedMap.each { String k, Map v ->
+                    returnMap.put(key + "." + k, v)
+                }
+            } else {
+                returnMap.put(key, value)
+            }
+        }
+        return returnMap
+    }
+
+}

--- a/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
@@ -60,6 +60,17 @@ class HelpMessage {
         log.info(getGroupHelpString(true))
     }
 
+    public printBeforeText() {
+        log.info(config.help.beforeText)
+    }
+
+    public printAfterText() {
+        if (hiddenParametersCount > 0) {
+            log.info(" ${colors.dim}!! Hiding ${hiddenParametersCount} params, use the `validation.showHiddenParams` config value to show them !!${colors.reset}")
+        }
+        log.info(config.help.afterText)
+    }
+
     //
     // Get a detailed help string from one parameter
     //

--- a/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/HelpMessage.groovy
@@ -31,7 +31,7 @@ class HelpMessage {
         addHelpParameters()
     }
 
-    public void printShortHelpMessage(String param) {
+    public String getShortHelpMessage(String param) {
         def String helpMessage = ""
         if (param) {
             def List<String> paramNames = param.tokenize(".") as List<String>
@@ -57,26 +57,28 @@ class HelpMessage {
         } else {
             helpMessage = getGroupHelpString()
         }
-        log.info(helpMessage)
+        return helpMessage
     }
 
-    public printFullHelpMessage() {
-        log.info(getGroupHelpString(true))
+    public String getFullHelpMessage() {
+        return getGroupHelpString(true)
     }
 
-    public printBeforeText() {
-        log.info(config.help.beforeText)
+    public String getBeforeText() {
+        def String beforeText = config.help.beforeText
         if (config.help.command) {
-            log.info("Typical pipeline command:\n")
-            log.info("  ${colors.cyan}${config.help.command}${colors.reset}\n")
+            beforeText += "Typical pipeline command:\n"
+            beforeText += "  ${colors.cyan}${config.help.command}${colors.reset}\n"
         }
     }
 
-    public printAfterText() {
+    public String getAfterText() {
+        def String afterText = ""
         if (hiddenParametersCount > 0) {
-            log.info(" ${colors.dim}!! Hiding ${hiddenParametersCount} param(s), use the `--${config.help.showHiddenParameter}` parameter to show them !!${colors.reset}")
+            afterText += " ${colors.dim}!! Hiding ${hiddenParametersCount} param(s), use the `--${config.help.showHiddenParameter}` parameter to show them !!${colors.reset}"
         }
-        log.info(config.help.afterText)
+        afterText += "-${colors.dim}----------------------------------------------------${colors.reset}-"
+        afterText += config.help.afterText
     }
 
     //

--- a/plugins/nf-schema/src/main/nextflow/validation/JsonSchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/JsonSchemaValidator.groovy
@@ -77,7 +77,7 @@ public class JsonSchemaValidator {
                 }
             }
 
-            def String[] locationList = instanceLocation.split("/").findAll { it != "" }
+            def List<String> locationList = instanceLocation.split("/").findAll { it != "" } as List
 
             if (locationList.size() > 0 && Utils.isInteger(locationList[0]) && validationType == "field") {
                 def Integer entryInteger = locationList[0] as Integer

--- a/plugins/nf-schema/src/main/nextflow/validation/SamplesheetConverter.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SamplesheetConverter.groovy
@@ -125,7 +125,7 @@ class SamplesheetConverter {
 
         if (input instanceof Map) {
             def List result = []
-            def LinkedHashMap properties = schema["properties"]
+            def Map properties = schema["properties"] as Map
             def Set unusedKeys = input.keySet() - properties.keySet()
             
             // Check for properties in the samplesheet that have not been defined in the schema
@@ -234,7 +234,7 @@ class SamplesheetConverter {
 
         if (input instanceof Map) {
             def Map result = [:]
-            def LinkedHashMap properties = schema["properties"]
+            def Map properties = schema["properties"] as Map
             def Set unusedKeys = input.keySet() - properties.keySet()
             
             // Check for properties in the samplesheet that have not been defined in the schema

--- a/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
@@ -356,155 +356,39 @@ class SchemaValidator extends PluginExtensionPoint {
         return new Tuple (expectedParams, enums)
     }
 
-
-    //
-    // Wrap too long text
-    //
-    String wrapText(String text) {
-        List olines = []
-        String oline = ""
-        text.split(" ").each() { wrd ->
-            if ((oline.size() + wrd.size()) <= terminalLength) {
-                oline += wrd + " "
-            } else {
-                olines += oline
-                oline = wrd + " "
-            }
-        }
-        olines += oline
-        return olines.join("\n")
-    }
-
     //
     // Beautify parameters for --help
     //
     @Function
     public String paramsHelp(
-        Map options = null,
+        Map options = [:],
         String command
     ) {
         // TODO add link to help message migration guide once created
-        log.warn("Using `paramsHelp()` is deprecated. Check out the help message migration guide: <url>")
-        def Map params = initialiseExpectedParams(session.params)
-
-        def String schemaFilename = options?.containsKey('parameters_schema') ? options.parameters_schema as String : config.parametersSchema
-        def colors = Utils.logColours(config.monochromeLogs)
-        Integer num_hidden = 0
-        String output  = ''
-        output        += 'Typical pipeline command:\n\n'
-        output        += "  ${colors.cyan}${command}${colors.reset}\n\n"
-        Map paramsMap = Utils.paramsLoad( Path.of(Utils.getSchemaPath(session.baseDir.toString(), schemaFilename)) )
-        Integer maxChars  = Utils.paramsMaxChars(paramsMap) + 1
-
-        // Make sure the hidden parameters count is 0
-        hiddenParametersCount = 0
-
-        // If a value is passed to help
-        if (params.help instanceof String) {
-            def String paramName = params.help
-            def List<String> paramNames = params.help.tokenize(".") as List<String>
-            def Map paramOptions = [:]
-            for (group in paramsMap.keySet()) {
-                def Map group_params = paramsMap.get(group) as Map // This gets the parameters of that particular group
-                if (group_params.containsKey(paramNames[0])) {
-                    paramOptions = group_params.get(paramNames[0]) as Map 
-                }
-            }
-            if (paramNames.size() > 1) {
-                paramNames.remove(0)
-                paramNames.each {
-                    paramOptions = (Map) paramOptions?.properties?[it] ?: [:]
-                }
-            }
-            if (!paramOptions) {
-                throw new Exception("Specified param '${paramName}' does not exist in JSON schema.")
-            }
-            output += getDetailedHelpString(paramName, paramOptions, colors)
-            output += "-${colors.dim}----------------------------------------------------${colors.reset}-"
-            return output
+        if (!options.containsKey("hideWarning") || options.hideWarning == false) {
+            log.warn("""
+Using `paramsHelp()` is not recommended. Check out the help message migration guide: <url>
+If you intended to use this function, please add the following option to the input of the function:
+    `hideWarning: true`
+            """)
         }
 
-        for (group in paramsMap.keySet()) {
-            Integer num_params = 0
-            String group_output = "$colors.underlined$colors.bold$group$colors.reset\n"
-            def Map group_params = paramsMap.get(group) as Map // This gets the parameters of that particular group
-            group_output += getHelpList(group_params, colors, maxChars).join("\n") + "\n"
-            if (group_output != "\n"){
-                output += group_output
-            }
-        }
-        if (num_hidden > 0){
-            output += "$colors.dim !! Hiding $num_hidden params, use the 'validation.showHiddenParams' config value to show them !!\n$colors.reset"
-        }
-        output += "-${colors.dim}----------------------------------------------------${colors.reset}-"
-        return output
-    }
-
-    //
-    // Get help text in string format
-    //
-    private List<String> getHelpList(Map<String,Map> params, Map colors, Integer maxChars, String parentParameter = "") {
-        def List<String> helpMessage = []
-        for (String paramName in params.keySet()) {
-            def Map paramOptions = params.get(paramName) as Map 
-            if (paramOptions.hidden && !config.help.showHidden) {
-                hiddenParametersCount += 1
-                continue
-            }
-            def String type = '[' + paramOptions.type + ']'
-            def String enumsString = ""
-            if (paramOptions.enum != null) {
-                def List enums = (List) paramOptions.enum
-                def String chopEnums = enums.join(", ")
-                if(chopEnums.length() > terminalLength){
-                    chopEnums = chopEnums.substring(0, terminalLength-5)
-                    chopEnums = chopEnums.substring(0, chopEnums.lastIndexOf(",")) + ", ..."
-                }
-                enumsString = " (accepted: " + chopEnums + ") "
-            }
-            def String description = paramOptions.description ? paramOptions.description as String + " " : ""
-            def defaultValue = paramOptions.default != null ? "[default: " + paramOptions.default.toString() + "] " : ''
-            def String nestedParamName = parentParameter ? parentParameter + "." + paramName : paramName
-            def String nestedString = paramOptions.properties ? "(This parameter has sub-parameters. Use '--help ${nestedParamName}' to see all sub-parameters) " : ""
-            def descriptionDefault = description + colors.dim + enumsString + defaultValue + colors.reset + nestedString
-            // Wrap long description texts
-            // Loosely based on https://dzone.com/articles/groovy-plain-text-word-wrap
-            if (descriptionDefault.length() > terminalLength){
-                descriptionDefault = wrapText(descriptionDefault)
-            }
-            helpMessage.add("  --" +  paramName.padRight(maxChars) + colors.dim + type.padRight(10) + colors.reset + descriptionDefault)
-        }
-        return helpMessage
-    }
-
-    //
-    // Get a detailed help string from one parameter
-    //
-    private String getDetailedHelpString(String paramName, Map paramOptions, Map colors) {
-        def String helpMessage = "--" + paramName + '\n'
-        for (option in paramOptions) {
-            def String key = option.key
-            if (key == "fa_icon" || (key == "type" && option.value == "object")) {
-                continue
-            }
-            if (key == "properties") {
-                def Map subParamsOptions = option.value as Map
-                def Integer maxChars = Utils.paramsMaxChars(subParamsOptions) + 2
-                def String subParamsHelpString = getHelpList(subParamsOptions, colors, maxChars, paramName)
-                    .collect {
-                        "      ." + it[4..it.length()-1]
-                    }
-                    .join("\n")
-                helpMessage += "    " + colors.dim + "options".padRight(11) + ": " + colors.reset + "\n" + subParamsHelpString + "\n"
-                continue
-            }
-            def String value = option.value
-            if (value.length() > terminalLength) {
-                value = wrapText(value)
-            }
-            helpMessage += "    " + colors.dim + key.padRight(11) + ": " + colors.reset + value + '\n'
-        }
-        return helpMessage
+        def Map params = session.params
+        def Map validationConfig = (Map)session.config.navigate("validation")
+        validationConfig.parametersSchema = options.containsKey('parameters_schema') ? options.parameters_schema as String : config.parametersSchema
+        validationConfig.help = (Map)validationConfig.help + [command: command, beforeText: "", afterText: ""]
+        def ValidationConfig copyConfig = new ValidationConfig(validationConfig, params)
+        def HelpMessage helpMessage = new HelpMessage(copyConfig, session)
+        def String help = helpMessage.getBeforeText()
+        def List<String> helpBodyLines = helpMessage.getShortHelpMessage(params.help && params.help instanceof String ? params.help : "").readLines()
+        help += helpBodyLines.findAll {
+            // Remove added ungrouped help parameters
+            !it.startsWith("--${copyConfig.help.shortParameter}") && 
+            !it.startsWith("--${copyConfig.help.fullParameter}") && 
+            !it.startsWith("--${copyConfig.help.showHiddenParameter}")
+        }.join("\n")
+        help += helpMessage.getAfterText()
+        return help
     }
 
     //

--- a/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
@@ -151,17 +151,17 @@ class SchemaValidator extends PluginExtensionPoint {
         def Boolean containsShortParameter = params.containsKey(config.help.shortParameter)
         if (config.help.enabled && (containsFullParameter || containsShortParameter)) {
             def HelpMessage helpMessage = new HelpMessage(config, session)
-            log.debug("Enabled checks to create a help message using --${config.help.fullParameter} and --${config.help.shortParameter}")
+            helpMessage.printBeforeText()
             if (containsFullParameter) {
                 log.debug("Printing out the full help message")
                 helpMessage.printFullHelpMessage()
-                System.exit(0)
             } else if (containsShortParameter) {
                 log.debug("Printing out the short help message")
                 def paramValue = params.get(config.help.shortParameter)
                 helpMessage.printShortHelpMessage(paramValue instanceof String ? paramValue : "")
-                System.exit(0)
             }
+            helpMessage.printAfterText()
+            System.exit(0)
         }
 
     }

--- a/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
@@ -146,7 +146,7 @@ class SchemaValidator extends PluginExtensionPoint {
 
         // Help message logic
         def Map params = session.params as Map
-        config = new ValidationConfig(session.config.navigate('validation') as Map, params)
+        config = new ValidationConfig(session?.config?.navigate('validation') as Map, params)
         def Boolean containsFullParameter = params.containsKey(config.help.fullParameter)
         def Boolean containsShortParameter = params.containsKey(config.help.shortParameter)
         if (config.help.enabled && (containsFullParameter || containsShortParameter)) {
@@ -443,7 +443,7 @@ class SchemaValidator extends PluginExtensionPoint {
     // Get help text in string format
     //
     private List<String> getHelpList(Map<String,Map> params, Map colors, Integer maxChars, String parentParameter = "") {
-        def List helpMessage = []
+        def List<String> helpMessage = []
         for (String paramName in params.keySet()) {
             def Map paramOptions = params.get(paramName) as Map 
             if (paramOptions.hidden && !config.showHiddenParams) {
@@ -545,7 +545,8 @@ class SchemaValidator extends PluginExtensionPoint {
             def Map groupSummary = getSummaryMapFromParams(params, paramsMap.get(group) as Map)
             paramsSummary.put(group, groupSummary)
         }
-        return [ 'Core Nextflow options' : workflowSummary ] << paramsSummary as LinkedHashMap
+        paramsSummary.put('Core Nextflow options', workflowSummary)
+        return paramsSummary
     }
 
 

--- a/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
@@ -150,17 +150,19 @@ class SchemaValidator extends PluginExtensionPoint {
         def Boolean containsFullParameter = params.containsKey(config.help.fullParameter)
         def Boolean containsShortParameter = params.containsKey(config.help.shortParameter)
         if (config.help.enabled && (containsFullParameter || containsShortParameter)) {
+            def String help = ""
             def HelpMessage helpMessage = new HelpMessage(config, session)
-            helpMessage.printBeforeText()
+            help += helpMessage.getBeforeText()
             if (containsFullParameter) {
                 log.debug("Printing out the full help message")
-                helpMessage.printFullHelpMessage()
+                help += helpMessage.getFullHelpMessage()
             } else if (containsShortParameter) {
                 log.debug("Printing out the short help message")
                 def paramValue = params.get(config.help.shortParameter)
-                helpMessage.printShortHelpMessage(paramValue instanceof String ? paramValue : "")
+                help += helpMessage.getShortHelpMessage(paramValue instanceof String ? paramValue : "")
             }
-            helpMessage.printAfterText()
+            help += helpMessage.getAfterText()
+            log.info(help)
             System.exit(0)
         }
 

--- a/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
@@ -150,7 +150,7 @@ class SchemaValidator extends PluginExtensionPoint {
         this.session = session
 
         // Help message logic
-        def Map params = session.params as Map
+        def Map params = (Map)session.params ?: [:]
         config = new ValidationConfig(session?.config?.navigate('validation') as Map, params)
         def Boolean containsFullParameter = params.containsKey(config.help.fullParameter) && params[config.help.fullParameter]
         def Boolean containsShortParameter = params.containsKey(config.help.shortParameter) && params[config.help.shortParameter]
@@ -447,7 +447,7 @@ class SchemaValidator extends PluginExtensionPoint {
         def List<String> helpMessage = []
         for (String paramName in params.keySet()) {
             def Map paramOptions = params.get(paramName) as Map 
-            if (paramOptions.hidden && !config.showHiddenParams) {
+            if (paramOptions.hidden && !config.help.showHidden) {
                 hiddenParametersCount += 1
                 continue
             }

--- a/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
@@ -145,8 +145,8 @@ class SchemaValidator extends PluginExtensionPoint {
         }
 
         // Help message logic
-        config = new ValidationConfig(session.config.navigate('validation') as Map)
         def Map params = session.params as Map
+        config = new ValidationConfig(session.config.navigate('validation') as Map, params)
         def Boolean containsFullParameter = params.containsKey(config.help.fullParameter)
         def Boolean containsShortParameter = params.containsKey(config.help.shortParameter)
         if (config.help.enabled && (containsFullParameter || containsShortParameter)) {

--- a/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
@@ -370,6 +370,8 @@ class SchemaValidator extends PluginExtensionPoint {
 Using `paramsHelp()` is not recommended. Check out the help message migration guide: <url>
 If you intended to use this function, please add the following option to the input of the function:
     `hideWarning: true`
+
+Please contact the pipeline maintainer(s) if you see this warning as a user.
             """)
         }
 

--- a/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
@@ -122,6 +122,9 @@ class SchemaValidator extends PluginExtensionPoint {
     // The configuration class
     private ValidationConfig config
 
+    // The session
+    private Session session
+
     @Override
     protected void init(Session session) {
         def plugins = session?.config?.navigate("plugins") as ArrayList
@@ -144,11 +147,13 @@ class SchemaValidator extends PluginExtensionPoint {
             """)
         }
 
+        this.session = session
+
         // Help message logic
         def Map params = session.params as Map
         config = new ValidationConfig(session?.config?.navigate('validation') as Map, params)
-        def Boolean containsFullParameter = params.containsKey(config.help.fullParameter)
-        def Boolean containsShortParameter = params.containsKey(config.help.shortParameter)
+        def Boolean containsFullParameter = params.containsKey(config.help.fullParameter) && params[config.help.fullParameter]
+        def Boolean containsShortParameter = params.containsKey(config.help.shortParameter) && params[config.help.shortParameter]
         if (config.help.enabled && (containsFullParameter || containsShortParameter)) {
             def String help = ""
             def HelpMessage helpMessage = new HelpMessage(config, session)
@@ -167,10 +172,6 @@ class SchemaValidator extends PluginExtensionPoint {
         }
 
     }
-
-    Session getSession(){
-        Global.getSession() as Session
-    }  
 
     boolean hasErrors() { errors.size()>0 }
     List<String> getErrors() { errors }

--- a/plugins/nf-schema/src/main/nextflow/validation/Utils.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/Utils.groovy
@@ -362,6 +362,6 @@ public class Utils {
     // Get the size of the longest string value in a list of strings
     //
     public static Integer longestStringLength( List<String> strings ) {
-        return Collections.max(strings.collect { it.size() })
+        return strings ? Collections.max(strings.collect { it.size() }) : 0
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/Utils.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/Utils.groovy
@@ -351,21 +351,17 @@ public class Utils {
     //
     // Get maximum number of characters across all parameter names
     //
-    public static Integer paramsMaxChars( Map paramsMap, Boolean noGroups = false) {
-        Integer maxChars = 0
-        for (group in paramsMap.keySet()) {
-            if(noGroups) {
-                if (group.size() > maxChars) {
-                    maxChars = group.size()
-                }
-            }
-            def Map group_params = (Map) paramsMap.get(group)  // This gets the parameters of that particular group
-            for (String param in group_params.keySet()) {
-                if (param.size() > maxChars) {
-                    maxChars = param.size()
-                }
-            }
-        }
-        return maxChars
+    public static Integer paramsMaxChars( Map paramsMap ) {
+        return Collections.max(paramsMap.collect { _, val -> 
+            def Map groupParams = val as Map
+            longestStringLength(groupParams.keySet() as List<String> )
+        })
+    }
+
+    //
+    // Get the size of the longest string value in a list of strings
+    //
+    public static Integer longestStringLength( List<String> strings ) {
+        return Collections.max(strings.collect { it.size() })
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/Utils.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/Utils.groovy
@@ -123,7 +123,7 @@ public class Utils {
     }
 
     // Resolve Schema path relative to main workflow directory
-    public static String getSchemaPath(String baseDir, String schemaFilename='nextflow_schema.json') {
+    public static String getSchemaPath(String baseDir, String schemaFilename) {
         if (Path.of(schemaFilename).exists()) {
             return schemaFilename
         } else {

--- a/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
@@ -20,19 +20,21 @@ class HelpConfig {
     final private Boolean enabled
     final private String  shortParameter
     final private String  fullParameter
+    final private String  showHiddenParameter
     final private String  beforeText
     final private String  afterText
     final private String  command
-    final private Boolean showHiddenParams
+    final private Boolean showHidden
 
-    HelpConfig(Map map, Boolean showHidden) {
+    HelpConfig(Map map, Map params) {
         def config = map ?: Collections.emptyMap()
-        enabled             = config.enabled            ?: false
-        shortParameter      = config.shortParameter     ?: "help"
-        fullParameter       = config.fullParameter      ?: "help_full"
-        beforeText          = config.beforeText         ?: ""
-        afterText           = config.afterText          ?: ""
-        command             = config.command            ?: ""
-        showHiddenParams    = config.showHiddenParams   ?: showHidden   ?: false
+        enabled             = config.enabled                    ?: false
+        shortParameter      = config.shortParameter             ?: "help"
+        fullParameter       = config.fullParameter              ?: "helpFull"
+        showHiddenParameter = config.showHiddenParameter        ?: "showHidden"
+        beforeText          = config.beforeText                 ?: ""
+        afterText           = config.afterText                  ?: ""
+        command             = config.command                    ?: ""
+        showHidden          = params.get(showHiddenParameter)   ?: config.showHidden    ?: false
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
@@ -23,14 +23,16 @@ class HelpConfig {
     final private String  beforeText
     final private String  afterText
     final private String  command
+    final private Boolean showHiddenParams
 
-    HelpConfig(Map map) {
+    HelpConfig(Map map, Boolean showHidden) {
         def config = map ?: Collections.emptyMap()
-        enabled         = config.enabled        ?: false
-        shortParameter  = config.shortParameter ?: "help"
-        fullParameter   = config.fullParameter  ?: "help_full"
-        beforeText      = config.beforeText     ?: ""
-        afterText       = config.afterText      ?: ""
-        command         = config.command        ?: ""
+        enabled             = config.enabled            ?: false
+        shortParameter      = config.shortParameter     ?: "help"
+        fullParameter       = config.fullParameter      ?: "help_full"
+        beforeText          = config.beforeText         ?: ""
+        afterText           = config.afterText          ?: ""
+        command             = config.command            ?: ""
+        showHiddenParams    = config.showHiddenParams   ?: showHidden   ?: false
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
@@ -35,6 +35,6 @@ class HelpConfig {
         beforeText          = config.beforeText                 ?: ""
         afterText           = config.afterText                  ?: ""
         command             = config.command                    ?: ""
-        showHidden          = params.get(showHiddenParameter)   ?: config.showHidden    ?: false
+        showHidden          = params.get(showHiddenParameter) ?: config.showHidden    ?: false
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
@@ -22,6 +22,7 @@ class HelpConfig {
     final private String  fullParameter
     final private String  beforeText
     final private String  afterText
+    final private String  command
 
     HelpConfig(Map map) {
         def config = map ?: Collections.emptyMap()
@@ -30,5 +31,6 @@ class HelpConfig {
         fullParameter   = config.fullParameter  ?: "help_full"
         beforeText      = config.beforeText     ?: ""
         afterText       = config.afterText      ?: ""
+        command         = config.command        ?: ""
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
@@ -1,0 +1,30 @@
+package nextflow.validation
+
+import groovy.util.logging.Slf4j
+import groovy.transform.PackageScope
+
+
+/**
+ * This class allows to model a specific configuration, extracting values from a map and converting
+ *
+ * We anotate this class as @PackageScope to restrict the access of their methods only to class in the
+ * same package
+ *
+ * @author : nvnieuwk <nicolas.vannieuwkerke@ugent.be>
+ *
+ */
+
+@Slf4j
+@PackageScope
+class HelpConfig {
+    final private Boolean enabled
+    final private String  shortParameter
+    final private String  fullParameter
+
+    HelpConfig(Map map) {
+        def config = map ?: Collections.emptyMap()
+        enabled         = config.enabled        ?: false
+        shortParameter  = config.shortParameter ?: "help"
+        fullParameter   = config.fullParameter  ?: "help_full"
+    }
+}

--- a/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
@@ -35,6 +35,6 @@ class HelpConfig {
         beforeText          = config.beforeText                 ?: ""
         afterText           = config.afterText                  ?: ""
         command             = config.command                    ?: ""
-        showHidden          = params.get(showHiddenParameter) ?: config.showHidden    ?: false
+        showHidden          = params.get(showHiddenParameter)   ?: config.showHidden    ?: false
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
@@ -17,14 +17,14 @@ import groovy.transform.PackageScope
 @Slf4j
 @PackageScope
 class HelpConfig {
-    final private Boolean enabled
-    final private String  shortParameter
-    final private String  fullParameter
-    final private String  showHiddenParameter
-    final private String  beforeText
-    final private String  afterText
-    final private String  command
-    final private Boolean showHidden
+    final public Boolean enabled
+    final public String  shortParameter
+    final public String  fullParameter
+    final public String  showHiddenParameter
+    final public String  beforeText
+    final public String  afterText
+    final public String  command
+    final public Boolean showHidden
 
     HelpConfig(Map map, Map params) {
         def config = map ?: Collections.emptyMap()

--- a/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/HelpConfig.groovy
@@ -20,11 +20,15 @@ class HelpConfig {
     final private Boolean enabled
     final private String  shortParameter
     final private String  fullParameter
+    final private String  beforeText
+    final private String  afterText
 
     HelpConfig(Map map) {
         def config = map ?: Collections.emptyMap()
         enabled         = config.enabled        ?: false
         shortParameter  = config.shortParameter ?: "help"
         fullParameter   = config.fullParameter  ?: "help_full"
+        beforeText      = config.beforeText     ?: ""
+        afterText       = config.afterText      ?: ""
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -27,17 +27,16 @@ class ValidationConfig {
 
     final private List<String> ignoreParams
 
-    ValidationConfig(Map map){
+    ValidationConfig(Map map, Map params){
         def config = map ?: Collections.emptyMap()
         lenientMode             = config.lenientMode            ?: false
         monochromeLogs          = config.monochromeLogs         ?: false
         failUnrecognisedParams  = config.failUnrecognisedParams ?: false
         if(config.showHiddenParams) {
-            log.warn("configuration option `validation.showHiddenParams` is deprecated, please use `validation.help.showHiddenParams` instead")
-            showHiddenParams = config.showHiddenParams
+            log.warn("configuration option `validation.showHiddenParams` is deprecated, please use `validation.help.showHidden` or the `--showHidden` parameter instead")
         }
         parametersSchema        = config.parametersSchema       ?: "nextflow_schema.json"
-        help                    = new HelpConfig(config.help as Map ?: [:], showHiddenParams)
+        help                    = new HelpConfig(config.help as Map ?: [:], params)
 
         if(config.ignoreParams && !(config.ignoreParams instanceof List<String>)) {
             throw new SchemaValidationException("Config value 'validation.ignoreParams' should be a list of String values")

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -21,8 +21,8 @@ class ValidationConfig {
     final private Boolean lenientMode
     final private Boolean monochromeLogs
     final private Boolean failUnrecognisedParams
-    final private Boolean showHiddenParams
     final private String  parametersSchema
+    final private Boolean showHiddenParams = false
     final private HelpConfig help
 
     final private List<String> ignoreParams
@@ -32,9 +32,12 @@ class ValidationConfig {
         lenientMode             = config.lenientMode            ?: false
         monochromeLogs          = config.monochromeLogs         ?: false
         failUnrecognisedParams  = config.failUnrecognisedParams ?: false
-        showHiddenParams        = config.showHiddenParams       ?: false
+        if(config.showHiddenParams) {
+            log.warn("configuration option `validation.showHiddenParams` is deprecated, please use `validation.help.showHiddenParams` instead")
+            showHiddenParams = config.showHiddenParams
+        }
         parametersSchema        = config.parametersSchema       ?: "nextflow_schema.json"
-        help                    = new HelpConfig(config.help as Map ?: [:])
+        help                    = new HelpConfig(config.help as Map ?: [:], showHiddenParams)
 
         if(config.ignoreParams && !(config.ignoreParams instanceof List<String>)) {
             throw new SchemaValidationException("Config value 'validation.ignoreParams' should be a list of String values")

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -22,6 +22,8 @@ class ValidationConfig {
     final private Boolean monochromeLogs
     final private Boolean failUnrecognisedParams
     final private Boolean showHiddenParams
+    final private String  parametersSchema
+    final private HelpConfig help
 
     final private List<String> ignoreParams
 
@@ -31,6 +33,8 @@ class ValidationConfig {
         monochromeLogs          = config.monochromeLogs         ?: false
         failUnrecognisedParams  = config.failUnrecognisedParams ?: false
         showHiddenParams        = config.showHiddenParams       ?: false
+        parametersSchema        = config.parametersSchema       ?: "nextflow_schema.json"
+        help                    = new HelpConfig(config.help as Map ?: [:])
 
         if(config.ignoreParams && !(config.ignoreParams instanceof List<String>)) {
             throw new SchemaValidationException("Config value 'validation.ignoreParams' should be a list of String values")

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -18,14 +18,14 @@ import groovy.transform.PackageScope
 @PackageScope
 class ValidationConfig {
 
-    final private Boolean lenientMode
-    final private Boolean monochromeLogs
-    final private Boolean failUnrecognisedParams
-    final private String  parametersSchema
-    final private Boolean showHiddenParams = false
-    final private HelpConfig help
+    final public Boolean lenientMode
+    final public Boolean monochromeLogs
+    final public Boolean failUnrecognisedParams
+    final public String  parametersSchema
+    final public Boolean showHiddenParams = false
+    final public HelpConfig help
 
-    final private List<String> ignoreParams
+    final public List<String> ignoreParams
 
     ValidationConfig(Map map, Map params){
         def config = map ?: Collections.emptyMap()

--- a/plugins/nf-schema/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-schema/src/resources/META-INF/MANIFEST.MF
@@ -3,4 +3,4 @@ Plugin-Id: nf-schema
 Plugin-Version: 2.1.0
 Plugin-Class: nextflow.validation.ValidationPlugin
 Plugin-Provider: nextflow
-Plugin-Requires: >=22.10.0
+Plugin-Requires: >=23.10.0

--- a/plugins/nf-schema/src/test/nextflow/validation/HelpMessageTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/HelpMessageTest.groovy
@@ -1,0 +1,492 @@
+package nextflow.validation
+
+import java.nio.file.Path
+
+import nextflow.plugin.Plugins
+import nextflow.plugin.TestPluginDescriptorFinder
+import nextflow.plugin.TestPluginManager
+import nextflow.plugin.extension.PluginExtensionProvider
+import org.pf4j.PluginDescriptorFinder
+import nextflow.Session
+import spock.lang.Specification
+import spock.lang.Shared
+import org.slf4j.Logger
+import org.junit.Rule
+import test.Dsl2Spec
+import test.OutputCapture
+
+/**
+ * @author : nvnieuwk <nicolas.vannieuwkerke@ugent.be>
+ */
+class HelpMessageTest extends Specification{
+
+    @Rule
+    OutputCapture capture = new OutputCapture()
+
+    @Shared String pluginsMode
+
+    Path root = Path.of('.').toAbsolutePath().normalize()
+    Path getRoot() { this.root }
+    String getRootString() { this.root.toString() }
+
+    private Session session
+
+    def setup() {
+        session = Mock(Session)
+        session.getBaseDir() >> getRoot()
+    }
+
+    def 'should get a short help message' () {
+        given:
+        def validationConfig = [
+            monochromeLogs: true,
+            parametersSchema: 'src/testResources/nextflow_schema.json',
+            help: [
+                enabled: true
+            ]
+        ]
+        def params = [:]
+        def config = new ValidationConfig(validationConfig, params)
+        def helpMessage = new HelpMessage(config, session)
+
+        when:
+        def help = helpMessage.getShortHelpMessage("")
+
+        then:
+        noExceptionThrown()
+        def expectedHelp = """--help            [boolean, string] Show the help message for all top level parameters. When a parameter is given to `--help`, the full 
+help message of that parameter will be printed. 
+--helpFull        [boolean]         Show the help message for all non-hidden parameters. 
+--showHidden      [boolean]         Show all hidden parameters in the help message. This needs to be used in combination with `--help` 
+or `--helpFull`. 
+
+Input/output options
+  --input         [string] Path to comma-separated file containing information about the samples in the experiment. 
+  --outdir        [string] The output directory where the results will be saved. You have to use absolute paths to storage on 
+Cloud infrastructure. 
+  --email         [string] Email address for completion summary. 
+  --multiqc_title [string] MultiQC report title. Printed as page header, used for filename if not otherwise specified. 
+
+Reference genome options
+  --genome        [string] Name of iGenomes reference. 
+  --fasta         [string] Path to FASTA genome file. 
+
+"""
+        def resultHelp = help.readLines()
+        expectedHelp.readLines().each {
+            assert help.contains(it)
+            resultHelp.removeElement(it)
+        }
+        assert resultHelp.size() == 0, "Found extra unexpected lines: ${resultHelp}"
+    }
+
+    def 'should get a short help message with hidden params - config' () {
+        given:
+        def validationConfig = [
+            monochromeLogs: true,
+            parametersSchema: 'src/testResources/nextflow_schema.json',
+            help: [
+                enabled: true,
+                showHidden: true
+            ]
+        ]
+        def params = [:]
+        def config = new ValidationConfig(validationConfig, params)
+        def helpMessage = new HelpMessage(config, session)
+
+        when:
+        def help = helpMessage.getShortHelpMessage("")
+
+        then:
+        noExceptionThrown()
+        def expectedHelp = """--help                         [boolean, string] Show the help message for all top level parameters. When a parameter is given to `--help`, the full 
+help message of that parameter will be printed. 
+--helpFull                     [boolean]         Show the help message for all non-hidden parameters. 
+--showHidden                   [boolean]         Show all hidden parameters in the help message. This needs to be used in combination with `--help` 
+or `--helpFull`. 
+
+Input/output options
+  --input                      [string] Path to comma-separated file containing information about the samples in the experiment. 
+  --outdir                     [string] The output directory where the results will be saved. You have to use absolute paths to storage on 
+Cloud infrastructure. 
+  --email                      [string] Email address for completion summary. 
+  --multiqc_title              [string] MultiQC report title. Printed as page header, used for filename if not otherwise specified. 
+
+Reference genome options
+  --genome                     [string]  Name of iGenomes reference. 
+  --fasta                      [string]  Path to FASTA genome file. 
+  --igenomes_base              [string]  Directory / URL base for iGenomes references. [default: s3://ngi-igenomes/igenomes] 
+  --igenomes_ignore            [boolean] Do not load the iGenomes reference config. 
+
+Institutional config options
+  --custom_config_version      [string] Git commit id for Institutional configs. [default: master] 
+  --custom_config_base         [string] Base directory for Institutional configs. [default: 
+https://raw.githubusercontent.com/nf-core/configs/master] 
+  --config_profile_name        [string] Institutional config name. 
+  --config_profile_description [string] Institutional config description. 
+  --config_profile_contact     [string] Institutional config contact information. 
+  --config_profile_url         [string] Institutional config URL link. 
+
+Max job request options
+  --max_cpus                   [integer] Maximum number of CPUs that can be requested for any single job. [default: 16] 
+  --max_memory                 [string]  Maximum amount of memory that can be requested for any single job. [default: 128.GB] 
+  --max_time                   [string]  Maximum amount of time that can be requested for any single job. [default: 240.h] 
+
+Generic options
+  --help                       [string, boolean] Display help text. 
+  --publish_dir_mode           [string]          Method used to save pipeline results to output directory.  (accepted: symlink, rellink, link, copy, 
+copyNoFollow, move) [default: copy] 
+  --email_on_fail              [string]          Email address for completion summary, only when pipeline fails. 
+  --plaintext_email            [boolean]         Send plain-text email instead of HTML. 
+  --max_multiqc_email_size     [string]          File size limit when attaching MultiQC reports to summary emails. [default: 25.MB] 
+  --monochrome_logs            [boolean]         Do not use coloured log outputs. 
+  --multiqc_config             [string]          Custom config file to supply to MultiQC. 
+  --tracedir                   [string]          Directory to keep pipeline Nextflow logs and reports. [default: \${params.outdir}/pipeline_info] 
+  --validate_params            [boolean]         Boolean whether to validate parameters against the schema at runtime [default: true] 
+  --validationShowHiddenParams [boolean]         Show all params when using `--help` 
+  --enable_conda               [boolean]         Run this workflow with Conda. You can also use '-profile conda' instead of providing this parameter. 
+
+"""
+        def resultHelp = help.readLines()
+        expectedHelp.readLines().each {
+            assert help.contains(it)
+            resultHelp.removeElement(it)
+        }
+        assert resultHelp.size() == 0, "Found extra unexpected lines: ${resultHelp}"
+    }
+
+    def 'should get a short help message with hidden params - param' () {
+        given:
+        def validationConfig = [
+            monochromeLogs: true,
+            parametersSchema: 'src/testResources/nextflow_schema.json',
+            help: [
+                enabled: true,
+                showHiddenParameter: "showMeThoseHiddenParams"
+            ]
+        ]
+        def params = [
+            showMeThoseHiddenParams:true
+        ]
+        def config = new ValidationConfig(validationConfig, params)
+        def helpMessage = new HelpMessage(config, session)
+
+        when:
+        def help = helpMessage.getShortHelpMessage("")
+
+        then:
+        noExceptionThrown()
+        def expectedHelp = """--help                         [boolean, string] Show the help message for all top level parameters. When a parameter is given to `--help`, the full 
+help message of that parameter will be printed. 
+--helpFull                     [boolean]         Show the help message for all non-hidden parameters. 
+--showMeThoseHiddenParams      [boolean]         Show all hidden parameters in the help message. This needs to be used in combination with `--help` 
+or `--helpFull`. 
+
+Input/output options
+  --input                      [string] Path to comma-separated file containing information about the samples in the experiment. 
+  --outdir                     [string] The output directory where the results will be saved. You have to use absolute paths to storage on 
+Cloud infrastructure. 
+  --email                      [string] Email address for completion summary. 
+  --multiqc_title              [string] MultiQC report title. Printed as page header, used for filename if not otherwise specified. 
+
+Reference genome options
+  --genome                     [string]  Name of iGenomes reference. 
+  --fasta                      [string]  Path to FASTA genome file. 
+  --igenomes_base              [string]  Directory / URL base for iGenomes references. [default: s3://ngi-igenomes/igenomes] 
+  --igenomes_ignore            [boolean] Do not load the iGenomes reference config. 
+
+Institutional config options
+  --custom_config_version      [string] Git commit id for Institutional configs. [default: master] 
+  --custom_config_base         [string] Base directory for Institutional configs. [default: 
+https://raw.githubusercontent.com/nf-core/configs/master] 
+  --config_profile_name        [string] Institutional config name. 
+  --config_profile_description [string] Institutional config description. 
+  --config_profile_contact     [string] Institutional config contact information. 
+  --config_profile_url         [string] Institutional config URL link. 
+
+Max job request options
+  --max_cpus                   [integer] Maximum number of CPUs that can be requested for any single job. [default: 16] 
+  --max_memory                 [string]  Maximum amount of memory that can be requested for any single job. [default: 128.GB] 
+  --max_time                   [string]  Maximum amount of time that can be requested for any single job. [default: 240.h] 
+
+Generic options
+  --help                       [string, boolean] Display help text. 
+  --publish_dir_mode           [string]          Method used to save pipeline results to output directory.  (accepted: symlink, rellink, link, copy, 
+copyNoFollow, move) [default: copy] 
+  --email_on_fail              [string]          Email address for completion summary, only when pipeline fails. 
+  --plaintext_email            [boolean]         Send plain-text email instead of HTML. 
+  --max_multiqc_email_size     [string]          File size limit when attaching MultiQC reports to summary emails. [default: 25.MB] 
+  --monochrome_logs            [boolean]         Do not use coloured log outputs. 
+  --multiqc_config             [string]          Custom config file to supply to MultiQC. 
+  --tracedir                   [string]          Directory to keep pipeline Nextflow logs and reports. [default: \${params.outdir}/pipeline_info] 
+  --validate_params            [boolean]         Boolean whether to validate parameters against the schema at runtime [default: true] 
+  --validationShowHiddenParams [boolean]         Show all params when using `--help` 
+  --enable_conda               [boolean]         Run this workflow with Conda. You can also use '-profile conda' instead of providing this parameter. 
+
+"""
+        def resultHelp = help.readLines()
+        expectedHelp.readLines().each {
+            assert help.contains(it)
+            resultHelp.removeElement(it)
+        }
+        assert resultHelp.size() == 0, "Found extra unexpected lines: ${resultHelp}"
+    }
+
+    def 'should get a full help message' () {
+        given:
+        def validationConfig = [
+            monochromeLogs: true,
+            parametersSchema: 'src/testResources/nextflow_schema_nested_parameters.json',
+            help: [
+                enabled: true
+            ]
+        ]
+        def params = [:]
+        def config = new ValidationConfig(validationConfig, params)
+        def helpMessage = new HelpMessage(config, session)
+
+        when:
+        def help = helpMessage.getFullHelpMessage()
+
+        then:
+        noExceptionThrown()
+        def expectedHelp = """--help              [boolean, string] Show the help message for all top level parameters. When a parameter is given to `--help`, the full 
+help message of that parameter will be printed. 
+--helpFull          [boolean]         Show the help message for all non-hidden parameters. 
+--showHidden        [boolean]         Show all hidden parameters in the help message. This needs to be used in combination with `--help` 
+or `--helpFull`. 
+
+Nested Parameters
+  --this.is.so.deep [boolean] so deep [default: true] 
+
+"""
+        def resultHelp = help.readLines()
+        expectedHelp.readLines().each {
+            assert help.contains(it)
+            resultHelp.removeElement(it)
+        }
+        assert resultHelp.size() == 0, "Found extra unexpected lines: ${resultHelp}"
+    }
+
+    def 'should get a detailed help message - nested' () {
+        given:
+        def validationConfig = [
+            monochromeLogs: true,
+            parametersSchema: 'src/testResources/nextflow_schema_nested_parameters.json',
+            help: [
+                enabled: true
+            ]
+        ]
+        def params = [:]
+        def config = new ValidationConfig(validationConfig, params)
+        def helpMessage = new HelpMessage(config, session)
+
+        when:
+        def help = helpMessage.getShortHelpMessage("this")
+
+        then:
+        noExceptionThrown()
+        def expectedHelp = """--this
+    description: this is this
+    options    : 
+      --this.is.so.deep [boolean] so deep [default: true] 
+
+"""
+        def resultHelp = help.readLines()
+        expectedHelp.readLines().each {
+            assert help.contains(it)
+            resultHelp.removeElement(it)
+        }
+        assert resultHelp.size() == 0, "Found extra unexpected lines: ${resultHelp}"
+    }
+
+    def 'should get a detailed help message - not nested' () {
+        given:
+        def validationConfig = [
+            monochromeLogs: true,
+            parametersSchema: 'src/testResources/nextflow_schema.json',
+            help: [
+                enabled: true
+            ]
+        ]
+        def params = [:]
+        def config = new ValidationConfig(validationConfig, params)
+        def helpMessage = new HelpMessage(config, session)
+
+        when:
+        def help = helpMessage.getShortHelpMessage("input")
+
+        then:
+        noExceptionThrown()
+        def expectedHelp = """--input
+    type       : string
+    format     : file-path
+    mimetype   : text/csv
+    pattern    : ^\\S+\\.(csv|tsv|yaml|json)\$
+    description: Path to comma-separated file containing information about the samples in the experiment.
+    help_text  : You will need to create a design file with information about the samples in your experiment before 
+running the pipeline. Use this parameter to specify its location. It has to be a comma-separated 
+file with 3 columns, and a header row. See [usage 
+docs](https://nf-co.re/testpipeline/usage#samplesheet-input). 
+
+"""
+        def resultHelp = help.readLines()
+        expectedHelp.readLines().each {
+            assert help.contains(it)
+            resultHelp.removeElement(it)
+        }
+        assert resultHelp.size() == 0, "Found extra unexpected lines: ${resultHelp}"
+    }
+
+    def 'should get a before text - with command' () {
+        given:
+        def validationConfig = [
+            monochromeLogs: true,
+            parametersSchema: 'src/testResources/nextflow_schema.json',
+            help: [
+                enabled: true,
+                command: "nextflow run test/test --profile test,docker --outdir results",
+                beforeText: """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas condimentum ligula ac metus sollicitudin rutrum. Vestibulum a lectus ipsum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Cras consequat placerat aliquet. Maecenas et vulputate nibh. Donec luctus, purus ut scelerisque ornare, sem nisl mollis libero, non faucibus nibh nunc ac nulla. Donec et pharetra neque. Etiam id nibh vel turpis ornare efficitur. Cras eu eros mi.
+Etiam at nulla ac dui ullamcorper viverra. Donec posuere imperdiet eros nec consequat. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam nec aliquam magna. Quisque nec dapibus velit, id convallis justo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Suspendisse bibendum ipsum quis nulla fringilla laoreet. Integer dictum, purus et pretium ultrices, nunc nisl vestibulum erat, et tempus ex massa eget nunc. Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer varius aliquam vestibulum. Proin sit amet lobortis ipsum. Vestibulum fermentum lorem ac erat pharetra, eu eleifend sapien hendrerit. Quisque id varius ex. Morbi et dui et libero varius tempus. Ut eu sagittis lorem, sed congue libero.
+"""
+            ]
+        ]
+        def params = [:]
+        def config = new ValidationConfig(validationConfig, params)
+        def helpMessage = new HelpMessage(config, session)
+
+        when:
+        def help = helpMessage.getBeforeText()
+
+        then:
+        noExceptionThrown()
+        def expectedHelp = """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas condimentum ligula ac metus sollicitudin rutrum. Vestibulum a lectus ipsum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Cras consequat placerat aliquet. Maecenas et vulputate nibh. Donec luctus, purus ut scelerisque ornare, sem nisl mollis libero, non faucibus nibh nunc ac nulla. Donec et pharetra neque. Etiam id nibh vel turpis ornare efficitur. Cras eu eros mi.
+Etiam at nulla ac dui ullamcorper viverra. Donec posuere imperdiet eros nec consequat. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam nec aliquam magna. Quisque nec dapibus velit, id convallis justo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Suspendisse bibendum ipsum quis nulla fringilla laoreet. Integer dictum, purus et pretium ultrices, nunc nisl vestibulum erat, et tempus ex massa eget nunc. Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer varius aliquam vestibulum. Proin sit amet lobortis ipsum. Vestibulum fermentum lorem ac erat pharetra, eu eleifend sapien hendrerit. Quisque id varius ex. Morbi et dui et libero varius tempus. Ut eu sagittis lorem, sed congue libero.
+Typical pipeline command:
+
+  nextflow run test/test --profile test,docker --outdir results
+
+"""
+        def resultHelp = help.readLines()
+        expectedHelp.readLines().each {
+            assert help.contains(it)
+            resultHelp.removeElement(it)
+        }
+        assert resultHelp.size() == 0, "Found extra unexpected lines: ${resultHelp}"
+    }
+
+    def 'should get a before text - without command' () {
+        given:
+        def validationConfig = [
+            monochromeLogs: true,
+            parametersSchema: 'src/testResources/nextflow_schema.json',
+            help: [
+                enabled: true,
+                beforeText: """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas condimentum ligula ac metus sollicitudin rutrum. Vestibulum a lectus ipsum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Cras consequat placerat aliquet. Maecenas et vulputate nibh. Donec luctus, purus ut scelerisque ornare, sem nisl mollis libero, non faucibus nibh nunc ac nulla. Donec et pharetra neque. Etiam id nibh vel turpis ornare efficitur. Cras eu eros mi.
+Etiam at nulla ac dui ullamcorper viverra. Donec posuere imperdiet eros nec consequat. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam nec aliquam magna. Quisque nec dapibus velit, id convallis justo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Suspendisse bibendum ipsum quis nulla fringilla laoreet. Integer dictum, purus et pretium ultrices, nunc nisl vestibulum erat, et tempus ex massa eget nunc. Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer varius aliquam vestibulum. Proin sit amet lobortis ipsum. Vestibulum fermentum lorem ac erat pharetra, eu eleifend sapien hendrerit. Quisque id varius ex. Morbi et dui et libero varius tempus. Ut eu sagittis lorem, sed congue libero.
+"""
+            ]
+        ]
+        def params = [:]
+        def config = new ValidationConfig(validationConfig, params)
+        def helpMessage = new HelpMessage(config, session)
+
+        when:
+        def help = helpMessage.getBeforeText()
+
+        then:
+        noExceptionThrown()
+        def expectedHelp = """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas condimentum ligula ac metus sollicitudin rutrum. Vestibulum a lectus ipsum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Cras consequat placerat aliquet. Maecenas et vulputate nibh. Donec luctus, purus ut scelerisque ornare, sem nisl mollis libero, non faucibus nibh nunc ac nulla. Donec et pharetra neque. Etiam id nibh vel turpis ornare efficitur. Cras eu eros mi.
+Etiam at nulla ac dui ullamcorper viverra. Donec posuere imperdiet eros nec consequat. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam nec aliquam magna. Quisque nec dapibus velit, id convallis justo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Suspendisse bibendum ipsum quis nulla fringilla laoreet. Integer dictum, purus et pretium ultrices, nunc nisl vestibulum erat, et tempus ex massa eget nunc. Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer varius aliquam vestibulum. Proin sit amet lobortis ipsum. Vestibulum fermentum lorem ac erat pharetra, eu eleifend sapien hendrerit. Quisque id varius ex. Morbi et dui et libero varius tempus. Ut eu sagittis lorem, sed congue libero.
+
+"""
+        def resultHelp = help.readLines()
+        expectedHelp.readLines().each {
+            assert help.contains(it)
+            resultHelp.removeElement(it)
+        }
+        assert resultHelp.size() == 0, "Found extra unexpected lines: ${resultHelp}"
+    }
+
+    def 'should get an after text' () {
+        given:
+        def validationConfig = [
+            monochromeLogs: true,
+            parametersSchema: 'src/testResources/nextflow_schema.json',
+            help: [
+                enabled: true,
+                afterText: """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas condimentum ligula ac metus sollicitudin rutrum. Vestibulum a lectus ipsum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Cras consequat placerat aliquet. Maecenas et vulputate nibh. Donec luctus, purus ut scelerisque ornare, sem nisl mollis libero, non faucibus nibh nunc ac nulla. Donec et pharetra neque. Etiam id nibh vel turpis ornare efficitur. Cras eu eros mi.
+Etiam at nulla ac dui ullamcorper viverra. Donec posuere imperdiet eros nec consequat. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam nec aliquam magna. Quisque nec dapibus velit, id convallis justo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Suspendisse bibendum ipsum quis nulla fringilla laoreet. Integer dictum, purus et pretium ultrices, nunc nisl vestibulum erat, et tempus ex massa eget nunc. Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer varius aliquam vestibulum. Proin sit amet lobortis ipsum. Vestibulum fermentum lorem ac erat pharetra, eu eleifend sapien hendrerit. Quisque id varius ex. Morbi et dui et libero varius tempus. Ut eu sagittis lorem, sed congue libero.
+"""
+            ]
+        ]
+        def params = [:]
+        def config = new ValidationConfig(validationConfig, params)
+        def helpMessage = new HelpMessage(config, session)
+
+        when:
+        def help = helpMessage.getAfterText()
+
+        then:
+        noExceptionThrown()
+        def expectedHelp = """------------------------------------------------------
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas condimentum ligula ac metus sollicitudin rutrum. Vestibulum a lectus ipsum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Cras consequat placerat aliquet. Maecenas et vulputate nibh. Donec luctus, purus ut scelerisque ornare, sem nisl mollis libero, non faucibus nibh nunc ac nulla. Donec et pharetra neque. Etiam id nibh vel turpis ornare efficitur. Cras eu eros mi.
+Etiam at nulla ac dui ullamcorper viverra. Donec posuere imperdiet eros nec consequat. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam nec aliquam magna. Quisque nec dapibus velit, id convallis justo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Suspendisse bibendum ipsum quis nulla fringilla laoreet. Integer dictum, purus et pretium ultrices, nunc nisl vestibulum erat, et tempus ex massa eget nunc. Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer varius aliquam vestibulum. Proin sit amet lobortis ipsum. Vestibulum fermentum lorem ac erat pharetra, eu eleifend sapien hendrerit. Quisque id varius ex. Morbi et dui et libero varius tempus. Ut eu sagittis lorem, sed congue libero.
+
+"""
+        def resultHelp = help.readLines()
+        expectedHelp.readLines().each {
+            assert help.contains(it)
+            resultHelp.removeElement(it)
+        }
+        assert resultHelp.size() == 0, "Found extra unexpected lines: ${resultHelp}"
+    }
+
+    def 'should get a short help message with after text' () {
+        given:
+        def validationConfig = [
+            monochromeLogs: true,
+            parametersSchema: 'src/testResources/nextflow_schema.json',
+            help: [
+                enabled: true
+            ]
+        ]
+        def params = [:]
+        def config = new ValidationConfig(validationConfig, params)
+        def helpMessage = new HelpMessage(config, session)
+
+        when:
+        def help = helpMessage.getShortHelpMessage("") + helpMessage.getAfterText()
+
+        then:
+        noExceptionThrown()
+        def expectedHelp = """--help            [boolean, string] Show the help message for all top level parameters. When a parameter is given to `--help`, the full 
+help message of that parameter will be printed. 
+--helpFull        [boolean]         Show the help message for all non-hidden parameters. 
+--showHidden      [boolean]         Show all hidden parameters in the help message. This needs to be used in combination with `--help` 
+or `--helpFull`. 
+
+Input/output options
+  --input         [string] Path to comma-separated file containing information about the samples in the experiment. 
+  --outdir        [string] The output directory where the results will be saved. You have to use absolute paths to storage on 
+Cloud infrastructure. 
+  --email         [string] Email address for completion summary. 
+  --multiqc_title [string] MultiQC report title. Printed as page header, used for filename if not otherwise specified. 
+
+Reference genome options
+  --genome        [string] Name of iGenomes reference. 
+  --fasta         [string] Path to FASTA genome file. 
+
+ !! Hiding 22 param(s), use the `--showHidden` parameter to show them !!
+------------------------------------------------------
+
+"""
+        def resultHelp = help.readLines()
+        expectedHelp.readLines().each {
+            assert help.contains(it)
+            resultHelp.removeElement(it)
+        }
+        assert resultHelp.size() == 0, "Found extra unexpected lines: ${resultHelp}"
+    }
+
+}

--- a/plugins/nf-schema/src/test/nextflow/validation/ParamsHelpTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/ParamsHelpTest.groovy
@@ -105,7 +105,9 @@ class ParamsHelpTest extends Dsl2Spec{
 
         when:
         def config = ["validation": [
-            "showHiddenParams": true
+            "help": [
+                "showHidden": true
+            ]
         ]]
         def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
         def stdout = capture

--- a/plugins/nf-schema/src/test/nextflow/validation/SamplesheetConverterTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/SamplesheetConverterTest.groovy
@@ -355,7 +355,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
                 .toString()
                 .readLines()
                 .collect {
-                    it.split("nextflow.validation.SamplesheetConverter - ")[-1]
+                    it.split("nextflow.validation.SamplesheetConverter -- ")[-1]
                 }
 
         then:


### PR DESCRIPTION
This PR completely revamps the help messages. 

List of changes:
1. Help messages now automatically show instead of using the `paramsHelp` function. The `paramsHelp` function is still present for backwards compatibility but will no longer be updated. A deprecation warning will also be printed now to prompt the users to migrate to the new system. (Is there a need to keep this function fully supported?)
2. Help messages can be configured using the following config options:
    - `validation.help.enabled`: Will check if the help parameters are given and print out the correct help message
    - `validation.help.shortParameter`: Change the parameter to use for the compact help message (`--help` by default)
    - `validation.help.fullParameter`: Change the parameter to use for the full help message (`--helpFull` by default)
    - `validation.help.showHiddenParameter`: Change the parameter to show hidden parameters in the help message (`--showHidden` by default)
    - `validation.help.beforeText`: Provides a way to add some custom text before the help message
    - `validation.help.afterText`: Provides a way to add some custom text after the help message
    - `validation.help.command`: Will add an example command to the help message
    - `validation.help.showHidden`: Enabling this options will make sure that the help message will also contain hidden parameters by default. This option replaces `validation.showHiddenParameters`, which will keep working for now but will also show a deprecation message.
3. These 3 options are possible to get as a help message:
    - Option 1: using `--help` => A help message with the non-nested parameters (Styling has not been applied on this example, comments (`#`) are also not in the real output)
```
# Ungrouped parameters
--testparams                   [object]  (This parameter has sub-parameters. Use '--help testparams' to see all sub-parameters) 

# Grouped Parameters
Input/output options
  --input                      [string]  Path to comma-separated file containing information about the samples in the experiment. 
  --nested_params              [object]  This is a nested parameter (This parameter has sub-parameters. Use '--help nested_params' to see all sub-parameters) 
```

    - Option 2: using `--help <parameter>` => A detailed help message for the specified parameter. This also works for nested parameters
```
--nested_params
    description: This is a nested parameter
    options    : 
      --nested_params.deep.hello [string]  hi 
      --nested_params.deep.bool  [boolean] boolean value 
      --nested_params.bye        [string]  This is goodbye 
```

    - Option 3: using `--helpFull` shows the help message from `--help` but with all nested parameters expanded
```
--testparams.test              [integer] 

Input/output options
  --input                      [string]  Path to comma-separated file containing information about the samples in the experiment. 
  --nested_params.deep.hello   [string]  hi 
  --nested_params.deep.bool    [boolean] boolean value 
  --nested_params.bye          [string]  This is goodbye 
```
4. Some other small changes 

TODOS:
- [x] Implement a better way to handle hidden files
- [x] Implement `validation.help.beforeText` and `validation.help.afterText`
- [x] Re-add the command option
- [x] Re-add the note about hidden parameters at the end of the help message