### PR TITLE
Fix the uniqueEntries filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # nextflow-io/nf-schema: Changelog
 
-# Unreleased
-
-## Bug fixes
-
-1. Resolved an issue where the UniqueEntriesEvaluator did not correctly detect non-unique combinations.
-
 # Version 2.1.1
 
 ## Bug fixes
@@ -13,6 +7,7 @@
 1. The help parameters are now no longer unexpected parameters when validating parameters.
 2. Fixed a typo in the docs
 3. Added a URL to the help message migration docs to the `paramsHelp()` deprecation message
+4. Resolved an issue where the UniqueEntriesEvaluator did not correctly detect non-unique combinations.
 
 # Version 2.1.0 - Tantanmen
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nextflow-io/nf-schema: Changelog
 
+# Unreleased
+
+## Bug fixes
+
+1. Resolved an issue where the UniqueEntriesEvaluator did not correctly detect non-unique combinations.
+
 # Version 2.1.1
 
 ## Bug fixes

--- a/plugins/nf-schema/src/main/nextflow/validation/CustomEvaluators/UniqueEntriesEvaluator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/CustomEvaluators/UniqueEntriesEvaluator.groovy
@@ -40,7 +40,7 @@ class UniqueEntriesEvaluator implements Evaluator {
             }
             def Map<String,JsonNode> filteredNodes = nodeEntry
                 .asObject()
-                .dropWhile { k,v -> !uniqueEntries.contains(k) }
+                .findAll { k,v -> uniqueEntries.contains(k) }
                 .collectEntries { k,v -> [k, v.asString()] }
             for (uniqueNode : uniques) {
                 if(filteredNodes.equals(uniqueNode)) {


### PR DESCRIPTION
The UniqueEntriesEvaluator does not seem to correctly detect non-unique combinations, at least in my testing. This fix ensures that the combination of values for the given keys is unique across all objects in the array.