### PR TITLE
feat: add nf_test_output to ignoreParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nextflow-io/nf-schema: Changelog
 
+# Version 2.1.2
+
+## Bug fixes
+
+1. The directory `nf_test_output` is now an ignored parameter during validation to support use of both `nf_test` and `nf_schema`.
+
 # Version 2.1.1
 
 ## Bug fixes

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -69,6 +69,7 @@ validation.showHiddenParams = <true|false> // default: false
 ## ignoreParams
 
 This option can be used to turn off the validation for certain parameters. It takes a list of parameter names as input.
+Currently, the parameter `nf_test_output` is added to `ignoreParams` by default.
 
 ```groovy
 validation.ignoreParams = ["param1", "param2"] // default: []

--- a/docs/parameters/validation.md
+++ b/docs/parameters/validation.md
@@ -66,6 +66,10 @@ The function causes Nextflow to exit immediately with an error.
     --8<-- "examples/validateParameters/pipeline/nextflow_schema.json"
     ```
 
+## Ignoring Parameters
+
+Users can turn off validation for specific parameters using `validation.ignoreParams`, which accepts a list of parameter names.
+
 ## Failing for unrecognized parameters
 
 When parameters which are not specified in the JSON Schema are provided, the parameter validation function returns a `WARNING`.

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -7,7 +7,7 @@ import groovy.transform.PackageScope
 /**
  * This class allows model an specific configuration, extracting values from a map and converting
  *
- * We anotate this class as @PackageScope to restrict the access of their methods only to class in the
+ * We annotate this class as @PackageScope to restrict the access of their methods only to class in the
  * same package
  *
  * @author : nvnieuwk <nicolas.vannieuwkerke@ugent.be>
@@ -49,5 +49,7 @@ class ValidationConfig {
             throw new SchemaValidationException("Config value 'validation.defaultIgnoreParams' should be a list of String values")
         }
         ignoreParams += config.defaultIgnoreParams ?: []
+        ignoreParams += 'nf_test_output' //ignore `nf_test_output` directory when using nf-test
+
     }
 }

--- a/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
@@ -429,6 +429,31 @@ class ValidateParametersTest extends Dsl2Spec{
         !stdout
     }
 
+    def 'should ignore nf_test_output param' () {
+        given:
+        def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()
+        def SCRIPT = """
+            params.input = 'src/testResources/correct.csv'
+            params.outdir = 'src/testResources/testDir'
+            params.nf_test_output = '/some/path'
+            include { validateParameters } from 'plugin/nf-schema'
+            
+            validateParameters(parameters_schema: '$schema')
+        """
+
+        when:
+        def config = [:]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('* --') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
     def 'should ignore default unexpected param' () {
         given:
         def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()


### PR DESCRIPTION
Users may run into issues when using both `nf-schema` and `nf-test`: specifically, if `validation.failUnrecognisedParams = true`, the output directory produced by `nf-test` is an unrecognized parameter unless explicitly ignored.

This PR adds `nf_test_output` (default output directory produced by `nf-test`) as an ignored parameter for `nf-schema`. This PR adds a test and updates docs and the CHANGELOG.md.