### PR TITLE
Add extra config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## New features
 
-1. Added a new configuration option `failUnrecognisedHeaders`. This the is the analogue to `failUnrecognisedParams`, but for samplesheet headers. The default is `false` which means that unrecognized headers throw a warning instead of an error.
+1. Added a new configuration option `validation.failUnrecognisedHeaders`. This is the analogue to `failUnrecognisedParams`, but for samplesheet headers. The default is `false` which means that unrecognized headers throw a warning instead of an error.
+2. Added a new configuration option `validation.summary.hideParams`. This option takes a list of parameter names to hide from the parameters summary created by `paramsSummaryMap()` and `paramsSummaryLog()`
 
 ## Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Version 2.2.0-dev
 
+## New features
+
+1. Added a new configuration option `failUnrecognisedHeaders`. This the is the analogue to `failUnrecognisedParams`, but for samplesheet headers. The default is `false` which means that unrecognized headers throw a warning instead of an error.
+
 ## Bug fixes
 
 1. Fixed a bug in `samplesheetToList` that caused output mixing when the function was used more than once in channel operators.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -54,6 +54,14 @@ By default the `validateParameters()` function will only give a warning if an un
 validation.failUnrecognisedParams = <true|false> // default: false
 ```
 
+## failUnrecognisedHeaders
+
+By default the `samplesheetToList()` function will only give a warning if an unrecognised header is present in the samplesheet. This usually indicates that a typo has been made and can be easily overlooked when the plugin only emits a warning. You can turn this warning into an error with the `failUnrecognisedHeaders` option.
+
+```groovy
+validation.failUnrecognisedHeaders = <true|false> // default: false
+```
+
 ## showHiddenParams
 
 !!! deprecated

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -226,3 +226,11 @@ validation.summary.afterText = "Please cite the pipeline owners when using this 
 !!! info
 
     All color values (like `\033[0;31m`, which means the color red) will be filtered out when `validation.monochromeLogs` is set to `true`
+
+### hideParams
+
+Takes a list of parameter names to exclude from the parameters summary created by `paramsSummaryMap()` and `paramsSummaryLog()`
+
+```groovy
+validation.summary.hideParams = ["param1", "nested.param"] // default: []
+```

--- a/plugins/nf-schema/src/main/nextflow/validation/SamplesheetConverter.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SamplesheetConverter.groovy
@@ -51,7 +51,6 @@ class SamplesheetConverter {
     }
 
     private static logUnrecognisedHeaders(String fileName) {
-        log.info("HEADERS: ${this.unrecognisedHeaders}" as String)
         def Set unrecognisedHeaders = this.unrecognisedHeaders as Set
         if(unrecognisedHeaders.size() > 0) {
             def String processedHeaders = unrecognisedHeaders.collect { "\t- ${it}" }.join("\n")

--- a/plugins/nf-schema/src/main/nextflow/validation/SamplesheetConverter.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SamplesheetConverter.groovy
@@ -51,6 +51,7 @@ class SamplesheetConverter {
     }
 
     private static logUnrecognisedHeaders(String fileName) {
+        log.info("HEADERS: ${this.unrecognisedHeaders}" as String)
         def Set unrecognisedHeaders = this.unrecognisedHeaders as Set
         if(unrecognisedHeaders.size() > 0) {
             def String processedHeaders = unrecognisedHeaders.collect { "\t- ${it}" }.join("\n")
@@ -95,8 +96,6 @@ class SamplesheetConverter {
             throw new SchemaValidationException(msg, validationErrors)
         }
 
-        logUnrecognisedHeaders(samplesheetFile.toString())
-
         // Convert
         def LinkedHashMap schemaMap = new JsonSlurper().parseText(schemaFile.text) as LinkedHashMap
         def List samplesheetList = Utils.fileToList(samplesheetFile, schemaFile)
@@ -115,7 +114,11 @@ class SamplesheetConverter {
             }
             return result
         }
+
+        logUnrecognisedHeaders(samplesheetFile.toString())
+
         return channelFormat
+
     }
 
     /*

--- a/plugins/nf-schema/src/main/nextflow/validation/SamplesheetConverter.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SamplesheetConverter.groovy
@@ -44,17 +44,22 @@ class SamplesheetConverter {
         this.meta.size() > 0
     }
 
-    private static List unusedHeaders = []
+    private static List unrecognisedHeaders = []
 
-    private static addUnusedHeader (String header) {
-        this.unusedHeaders.add(header)
+    private static addUnrecognisedHeader (String header) {
+        this.unrecognisedHeaders.add(header)
     }
 
-    private static logUnusedHeadersWarning(String fileName) {
-        def Set unusedHeaders = this.unusedHeaders as Set
-        if(unusedHeaders.size() > 0) {
-            def String processedHeaders = unusedHeaders.collect { "\t- ${it}" }.join("\n")
-            log.warn("Found the following unidentified headers in ${fileName}:\n${processedHeaders}" as String)
+    private static logUnrecognisedHeaders(String fileName) {
+        def Set unrecognisedHeaders = this.unrecognisedHeaders as Set
+        if(unrecognisedHeaders.size() > 0) {
+            def String processedHeaders = unrecognisedHeaders.collect { "\t- ${it}" }.join("\n")
+            def String msg = "Found the following unidentified headers in ${fileName}:\n${processedHeaders}\n" as String
+            if( config.failUnrecognisedHeaders ) {
+                throw new SchemaValidationException(msg)
+            } else {
+                log.warn(msg)
+            }
         }
     }
 
@@ -90,6 +95,8 @@ class SamplesheetConverter {
             throw new SchemaValidationException(msg, validationErrors)
         }
 
+        logUnrecognisedHeaders(samplesheetFile.toString())
+
         // Convert
         def LinkedHashMap schemaMap = new JsonSlurper().parseText(schemaFile.text) as LinkedHashMap
         def List samplesheetList = Utils.fileToList(samplesheetFile, schemaFile)
@@ -108,7 +115,6 @@ class SamplesheetConverter {
             }
             return result
         }
-        logUnusedHeadersWarning(samplesheetFile.toString())
         return channelFormat
     }
 
@@ -127,7 +133,7 @@ class SamplesheetConverter {
             def Set unusedKeys = input.keySet() - properties.keySet()
             
             // Check for properties in the samplesheet that have not been defined in the schema
-            unusedKeys.each{addUnusedHeader("${headerPrefix}${it}" as String)}
+            unusedKeys.each{addUnrecognisedHeader("${headerPrefix}${it}" as String)}
 
             // Loop over every property to maintain the correct order
             properties.each { property, schemaValues ->
@@ -236,7 +242,7 @@ class SamplesheetConverter {
             def Set unusedKeys = input.keySet() - properties.keySet()
             
             // Check for properties in the samplesheet that have not been defined in the schema
-            unusedKeys.each{addUnusedHeader("${headerPrefix}${it}" as String)}
+            unusedKeys.each{addUnrecognisedHeader("${headerPrefix}${it}" as String)}
 
             // Loop over every property to maintain the correct order
             properties.each { property, schemaValues ->

--- a/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/SchemaValidator.groovy
@@ -432,6 +432,19 @@ Please contact the pipeline maintainer(s) if you see this warning as a user.
         def Map paramsMap = Utils.paramsLoad( Path.of(Utils.getSchemaPath(session.baseDir.toString(), schemaFilename)) )
         for (group in paramsMap.keySet()) {
             def Map groupSummary = getSummaryMapFromParams(params, paramsMap.get(group) as Map)
+            config.summary.hideParams.each { hideParam ->
+                def List<String> hideParamList = hideParam.tokenize(".") as List<String>
+                def Integer indexCounter = 0
+                def Map nestedSummary = groupSummary
+                if(hideParamList.size() >= 2 ) {
+                    hideParamList[0..-2].each { it ->
+                        nestedSummary = nestedSummary?.get(it, null)
+                    }
+                }
+                if(nestedSummary != null ) {
+                    nestedSummary.remove(hideParamList[-1])
+                }
+            }
             paramsSummary.put(group, groupSummary)
         }
         paramsSummary.put('Core Nextflow options', workflowSummary)

--- a/plugins/nf-schema/src/main/nextflow/validation/config/SummaryConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/SummaryConfig.groovy
@@ -19,6 +19,7 @@ import groovy.transform.PackageScope
 class SummaryConfig {
     final public String beforeText
     final public String afterText
+    final public List<String> hideParams
 
     SummaryConfig(Map map, Boolean monochromeLogs) {
         def config = map ?: Collections.emptyMap()
@@ -29,5 +30,6 @@ class SummaryConfig {
             beforeText  = config.beforeText ?: ""
             afterText   = config.afterText  ?: ""
         }
+        this.hideParams = config.hideParams ?: []
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -21,6 +21,7 @@ class ValidationConfig {
     final public Boolean lenientMode
     final public Boolean monochromeLogs
     final public Boolean failUnrecognisedParams
+    final public Boolean failUnrecognisedHeaders
     final public String  parametersSchema
     final public Boolean showHiddenParams
     final public HelpConfig help
@@ -30,10 +31,11 @@ class ValidationConfig {
 
     ValidationConfig(Map map, Map params){
         def config = map ?: Collections.emptyMap()
-        lenientMode             = config.lenientMode            ?: false
-        monochromeLogs          = config.monochromeLogs         ?: false
-        failUnrecognisedParams  = config.failUnrecognisedParams ?: false
-        showHiddenParams        = config.showHiddenParams       ?: false
+        lenientMode             = config.lenientMode                ?: false
+        monochromeLogs          = config.monochromeLogs             ?: false
+        failUnrecognisedParams  = config.failUnrecognisedParams     ?: false
+        failUnrecognisedHeaders = config.failUnrecognisedHeaders    ?: false
+        showHiddenParams        = config.showHiddenParams           ?: false
         if(config.containsKey("showHiddenParams")) {
             log.warn("configuration option `validation.showHiddenParams` is deprecated, please use `validation.help.showHidden` or the `--showHidden` parameter instead")
         }


### PR DESCRIPTION
Adds two new configuration options:

1. `validation.failUnrecognisedHeaders` which will fail when unrecognised headers have been detected in the samplesheet instead of emitting a warning
2. `validation.summary.hideParams` which takes a list of parameters to exclude from the summary created by the plugin