### PR TITLE
Move the help message code to an observer

### DIFF
--- a/plugins/nf-schema/src/main/nextflow/validation/ValidationExtension.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/ValidationExtension.groovy
@@ -38,7 +38,7 @@ import org.yaml.snakeyaml.Yaml
 
 @Slf4j
 @CompileStatic
-class SchemaValidator extends PluginExtensionPoint {
+class ValidationExtension extends PluginExtensionPoint {
 
     final List<String> NF_OPTIONS = [
             // Options for base `nextflow` command
@@ -152,24 +152,6 @@ class SchemaValidator extends PluginExtensionPoint {
         // Help message logic
         def Map params = (Map)session.params ?: [:]
         config = new ValidationConfig(session?.config?.navigate('validation') as Map, params)
-        def Boolean containsFullParameter = params.containsKey(config.help.fullParameter) && params[config.help.fullParameter]
-        def Boolean containsShortParameter = params.containsKey(config.help.shortParameter) && params[config.help.shortParameter]
-        if (config.help.enabled && (containsFullParameter || containsShortParameter)) {
-            def String help = ""
-            def HelpMessage helpMessage = new HelpMessage(config, session)
-            help += helpMessage.getBeforeText()
-            if (containsFullParameter) {
-                log.debug("Printing out the full help message")
-                help += helpMessage.getFullHelpMessage()
-            } else if (containsShortParameter) {
-                log.debug("Printing out the short help message")
-                def paramValue = params.get(config.help.shortParameter)
-                help += helpMessage.getShortHelpMessage(paramValue instanceof String ? paramValue : "")
-            }
-            help += helpMessage.getAfterText()
-            log.info(help)
-            System.exit(0)
-        }
 
     }
 

--- a/plugins/nf-schema/src/main/nextflow/validation/ValidationObserver.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/ValidationObserver.groovy
@@ -1,0 +1,37 @@
+package nextflow.validation
+
+import groovy.util.logging.Slf4j
+
+import nextflow.processor.TaskHandler
+import nextflow.trace.TraceObserver
+import nextflow.trace.TraceRecord
+import nextflow.Session
+
+@Slf4j
+class ValidationObserver implements TraceObserver {
+    
+    @Override
+    void onFlowCreate(Session session) {
+        // Help message logic
+        def Map params = (Map)session.params ?: [:]
+        def ValidationConfig config = new ValidationConfig(session?.config?.navigate('validation') as Map, params)
+        def Boolean containsFullParameter = params.containsKey(config.help.fullParameter) && params[config.help.fullParameter]
+        def Boolean containsShortParameter = params.containsKey(config.help.shortParameter) && params[config.help.shortParameter]
+        if (config.help.enabled && (containsFullParameter || containsShortParameter)) {
+            def String help = ""
+            def HelpMessage helpMessage = new HelpMessage(config, session)
+            help += helpMessage.getBeforeText()
+            if (containsFullParameter) {
+                log.debug("Printing out the full help message")
+                help += helpMessage.getFullHelpMessage()
+            } else if (containsShortParameter) {
+                log.debug("Printing out the short help message")
+                def paramValue = params.get(config.help.shortParameter)
+                help += helpMessage.getShortHelpMessage(paramValue instanceof String ? paramValue : "")
+            }
+            help += helpMessage.getAfterText()
+            log.info(help)
+            System.exit(0)
+        }
+    }
+}

--- a/plugins/nf-schema/src/main/nextflow/validation/ValidationObserverFactory.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/ValidationObserverFactory.groovy
@@ -1,0 +1,15 @@
+package nextflow.validation
+
+import nextflow.Session
+import nextflow.trace.TraceObserver
+import nextflow.trace.TraceObserverFactory
+
+class ValidationObserverFactory implements TraceObserverFactory {
+
+    @Override
+    Collection<TraceObserver> create(Session session) {
+        // Only enable the trace observer when a help message needs to be printed
+        final enabled = session.config.navigate('validation.help.enabled')
+        return enabled ? [ new ValidationObserver() ] : []
+    }
+}

--- a/plugins/nf-schema/src/resources/META-INF/extensions.idx
+++ b/plugins/nf-schema/src/resources/META-INF/extensions.idx
@@ -1,1 +1,2 @@
-nextflow.validation.SchemaValidator
+nextflow.validation.ValidationExtension
+nextflow.validation.ValidationObserverFactory


### PR DESCRIPTION
Moves the help message code from the extension point to an observer. This will fix the occassion when a user only wants to use the help message without using any functions of the plugin. 

Previously the help message would only be created once a function was imported.

This PR also updates some class names to have them make more sense.