### PR TITLE
Navbar: Reorganise

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,12 +5,11 @@ site_url: https://nextflow-io.github.io/nf-schema/latest/
 edit_uri: edit/master/docs/
 
 nav:
-  - Home:
-      - index.md
+  - Home: index.md
+  - Introduction:
       - background.md
       - migration_guide.md
-  - Schema:
-      - nextflow_schema/index.md
+      - Schema: nextflow_schema/index.md
       - nextflow_schema/create_schema.md
       - nextflow_schema/nextflow_schema_specification.md
       - nextflow_schema/sample_sheet_schema_specification.md


### PR DESCRIPTION
- Homepage outside of a group, to help mobile nav
- Moved background + migration into renamed 'introduction' section

This should fix #102 as the homepage no longer opens inside a nested nav group on mobile:

https://github.com/user-attachments/assets/05e5af87-e584-43dc-80da-51514c41ec74

