### PR TITLE
Allow `patternProperties` to with parameter validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Improvements
 
 1. Slow uniqueness check (> 2hrs for 100k samples) made 400x faster by switching from `findAll` to a `subMap` for isolating the required unique fields.
+2. `patternProperties` now has greater support, with no warnings about invalid parameters which actually match a pattern
 
 ## Changes
 

--- a/plugins/nf-schema/src/main/nextflow/validation/samplesheet/SamplesheetConverter.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/samplesheet/SamplesheetConverter.groovy
@@ -101,7 +101,8 @@ class SamplesheetConverter {
         // Validate
         final validator = new JsonSchemaValidator(config)
         def JSONArray samplesheet = fileToJson(samplesheetFile, schemaFile) as JSONArray
-        def List<String> validationErrors = validator.validate(samplesheet, schemaFile.text)
+        def Tuple2<List<String>,List<String>> validationResults = validator.validate(samplesheet, schemaFile.text)
+        def validationErrors = validationResults[0]
         if (validationErrors) {
             def msg = "${colors.red}The following errors have been detected in ${samplesheetFile.toString()}:\n\n" + validationErrors.join('\n').trim() + "\n${colors.reset}\n"
             log.error("Validation of samplesheet failed!")

--- a/plugins/nf-schema/src/main/nextflow/validation/utils/Common.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/utils/Common.groovy
@@ -1,9 +1,12 @@
 package nextflow.validation.utils
 
+import org.json.JSONObject
+import org.json.JSONArray
 import org.json.JSONPointer
 import org.json.JSONPointerException
 import groovy.util.logging.Slf4j
 import java.nio.file.Path
+import java.util.stream.IntStream
 
 /**
  * A collection of commonly used functions
@@ -71,5 +74,25 @@ public class Common {
             return m.findResult { element -> findDeep(element, key) }
         }
         return null
+    }
+
+    public static void findAllKeys(Object object, String key, List<String> finalKeys, String sep) {
+        if (object instanceof JSONObject) {
+            JSONObject jsonObject = (JSONObject) object;
+
+            jsonObject.keySet().forEach{ childKey ->
+                findAllKeys(jsonObject.get(childKey), key != null ? key + sep + childKey : childKey, finalKeys, sep)
+            };
+        } else if (object instanceof JSONArray) {
+            JSONArray jsonArray = (JSONArray) object;
+            finalKeys.add(key);
+
+            IntStream.range(0, jsonArray.length())
+                    .mapToObj(jsonArray::get)
+                    .forEach{ jObj -> findAllKeys(jObj, key, finalKeys, sep)};
+        }
+        else{
+            finalKeys.add(key);
+        }
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/utils/Common.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/utils/Common.groovy
@@ -76,7 +76,7 @@ public class Common {
         return null
     }
 
-    public static void findAllKeys(Object object, String key, List<String> finalKeys, String sep) {
+    public static void findAllKeys(Object object, String key, Set<String> finalKeys, String sep) {
         if (object instanceof JSONObject) {
             JSONObject jsonObject = (JSONObject) object;
 
@@ -85,14 +85,17 @@ public class Common {
             };
         } else if (object instanceof JSONArray) {
             JSONArray jsonArray = (JSONArray) object;
-            finalKeys.add(key);
+            key != null ? finalKeys.add(key) : ''
 
             IntStream.range(0, jsonArray.length())
                     .mapToObj(jsonArray::get)
                     .forEach{ jObj -> findAllKeys(jObj, key, finalKeys, sep)};
         }
         else{
-            finalKeys.add(key);
+            key != null ? finalKeys.add(key) : ''
         }
+    }
+    public static String kebabToCamel(String s) {
+        return s.replaceAll( "(-)([A-Za-z0-9])", { Object[] it -> it[2].toUpperCase() } )
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/validators/JsonSchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/validators/JsonSchemaValidator.groovy
@@ -14,6 +14,7 @@ import java.util.regex.Pattern
 import java.util.regex.Matcher
 
 import static nextflow.validation.utils.Common.getValueFromJsonPointer
+import static nextflow.validation.utils.Common.findAllKeys
 import static nextflow.validation.utils.Types.isInteger
 import nextflow.validation.config.ValidationConfig
 import nextflow.validation.exceptions.SchemaValidationException
@@ -38,7 +39,7 @@ public class JsonSchemaValidator {
         this.config = config
     }
 
-    private List<String> validateObject(JsonNode input, String validationType, Object rawJson, String schemaString) {
+    private Tuple2<List<String>,List<String>> validateObject(JsonNode input, String validationType, Object rawJson, String schemaString) {
         def JSONObject schema = new JSONObject(schemaString)
         def String draft = getValueFromJsonPointer("#/\$schema", schema)
         if(draft != "https://json-schema.org/draft/2020-12/schema") {
@@ -104,16 +105,33 @@ public class JsonSchemaValidator {
             errors.add(printableError)
 
         }
-        return errors
+        def List<String> unevaluated = getUnevaluated(result, rawJson)
+        return Tuple.tuple(errors, unevaluated)
     }
 
-    public List<String> validate(JSONArray input, String schemaString) {
+    public Tuple2<List<String>,List<String>> validate(JSONArray input, String schemaString) {
         def JsonNode jsonInput = new OrgJsonNode.Factory().wrap(input)
         return this.validateObject(jsonInput, "field", input, schemaString)
     }
 
-    public List<String> validate(JSONObject input, String schemaString) {
+    public Tuple2<List<String>,List<String>> validate(JSONObject input, String schemaString) {
         def JsonNode jsonInput = new OrgJsonNode.Factory().wrap(input)
         return this.validateObject(jsonInput, "parameter", input, schemaString)
+    }
+
+    public static List<String> getUnevaluated(Validator.Result result, Object rawJson) {
+        def List<String> evaluated = []
+        result.getAnnotations().each{ anno ->
+            if(anno.keyword in ["properties", "patternProperties", "additionalProperties"]){
+                evaluated.addAll(
+                    anno.annotation.collect{ it ->
+                    "${anno.instanceLocation.toString()}/${it.toString()}".replaceAll("^/+", "")
+                    }
+                )
+            }
+        }
+        def List<String> all_keys = []
+        findAllKeys(rawJson, null, all_keys, '/')
+        return all_keys.findAll{ it -> !evaluated.contains(it) }
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/validators/JsonSchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/validators/JsonSchemaValidator.groovy
@@ -15,6 +15,7 @@ import java.util.regex.Matcher
 
 import static nextflow.validation.utils.Common.getValueFromJsonPointer
 import static nextflow.validation.utils.Common.findAllKeys
+import static nextflow.validation.utils.Common.kebabToCamel
 import static nextflow.validation.utils.Types.isInteger
 import nextflow.validation.config.ValidationConfig
 import nextflow.validation.exceptions.SchemaValidationException
@@ -120,7 +121,7 @@ public class JsonSchemaValidator {
     }
 
     public static List<String> getUnevaluated(Validator.Result result, Object rawJson) {
-        def List<String> evaluated = []
+        def Set<String> evaluated = []
         result.getAnnotations().each{ anno ->
             if(anno.keyword in ["properties", "patternProperties", "additionalProperties"]){
                 evaluated.addAll(
@@ -130,8 +131,10 @@ public class JsonSchemaValidator {
                 )
             }
         }
-        def List<String> all_keys = []
+        def Set<String> all_keys = []
         findAllKeys(rawJson, null, all_keys, '/')
-        return all_keys.findAll{ it -> !evaluated.contains(it) }
+        def unevaluated_ = all_keys - evaluated
+        def unevaluated = unevaluated_.collect{ it -> !evaluated.contains(kebabToCamel(it)) ? it : null }
+        return unevaluated - null
     }
 }

--- a/plugins/nf-schema/src/main/nextflow/validation/validators/evaluators/SchemaEvaluator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/validators/evaluators/SchemaEvaluator.groovy
@@ -56,7 +56,8 @@ class SchemaEvaluator implements Evaluator {
         def String schemaContents = Files.readString( Path.of(schemaFull) )
         def validator = new JsonSchemaValidator(config)
 
-        def List<String> validationErrors = validator.validate(json, schemaContents)
+        def Tuple2<List<String>,List<String>> validationResult = validator.validate(json, schemaContents)
+        def validationErrors = validationResult[0]
         if (validationErrors) {
             def List<String> errors = ["Validation of file failed:"] + validationErrors.collect { "\t${it}" as String}
             return Evaluator.Result.failure(errors.join("\n"))

--- a/plugins/nf-schema/src/test/nextflow/validation/HelpMessageCreatorTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/HelpMessageCreatorTest.groovy
@@ -148,6 +148,7 @@ copyNoFollow, move) [default: copy]
   --validate_params            [boolean]         Boolean whether to validate parameters against the schema at runtime [default: true] 
   --validationShowHiddenParams [boolean]         Show all params when using `--help` 
   --enable_conda               [boolean]         Run this workflow with Conda. You can also use '-profile conda' instead of providing this parameter. 
+  --testCamelCase              [string]          A camelCase param 
 
 """
         def resultHelp = help.readLines()
@@ -225,6 +226,7 @@ copyNoFollow, move) [default: copy]
   --validate_params            [boolean]         Boolean whether to validate parameters against the schema at runtime [default: true] 
   --validationShowHiddenParams [boolean]         Show all params when using `--help` 
   --enable_conda               [boolean]         Run this workflow with Conda. You can also use '-profile conda' instead of providing this parameter. 
+  --testCamelCase              [string]          A camelCase param 
 
 """
         def resultHelp = help.readLines()
@@ -480,7 +482,7 @@ Reference genome options
   --genome        [string] Name of iGenomes reference. 
   --fasta         [string] Path to FASTA genome file. 
 
- !! Hiding 22 param(s), use the `--showHidden` parameter to show them !!
+ !! Hiding 23 param(s), use the `--showHidden` parameter to show them !!
 ------------------------------------------------------
 
 """

--- a/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
@@ -427,6 +427,31 @@ class ValidateParametersTest extends Dsl2Spec{
         !stdout
     }
 
+    def 'should find unexpected param kebab-case not like camelCase' () {
+        given:
+        def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()
+        def SCRIPT = """
+            params.input = 'src/testResources/correct.csv'
+            params.outdir = 'src/testResources/testDir'
+            params['test-kebab-bug'] = 'a real kebab bug'
+            include { validateParameters } from 'plugin/nf-schema'
+            
+            validateParameters(parameters_schema: '$schema')
+        """
+
+        when:
+        def config = [:]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('* --') ? it : null }
+
+        then:
+        noExceptionThrown()
+        stdout.size() >= 1
+        stdout.contains("* --test-kebab-bug: a real kebab bug")
+    }
 
     def 'should ignore unexpected param' () {
         given:

--- a/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
@@ -377,6 +377,31 @@ class ValidateParametersTest extends Dsl2Spec{
         stdout.contains("* --xyz: /some/path")
     }
 
+    def 'should not find unexpected params patternProperties' () {
+        given:
+        def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()
+        def SCRIPT = """
+            params.input = 'src/testResources/correct.csv'
+            params.outdir = 'src/testResources/testDir'
+            params.pattern_xyz = 'abc'
+            include { validateParameters } from 'plugin/nf-schema'
+            
+            validateParameters(parameters_schema: '$schema')
+        """
+
+        when:
+        def config = [:]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('* --') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
     def 'should ignore unexpected param' () {
         given:
         def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()

--- a/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
@@ -402,6 +402,32 @@ class ValidateParametersTest extends Dsl2Spec{
         !stdout
     }
 
+    def 'should ignore unexpected param kebab-case like camelCase' () {
+        given:
+        def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()
+        def SCRIPT = """
+            params.input = 'src/testResources/correct.csv'
+            params.outdir = 'src/testResources/testDir'
+            params.testCamelCase = 'aCamelBug'
+            include { validateParameters } from 'plugin/nf-schema'
+            
+            validateParameters(parameters_schema: '$schema')
+        """
+
+        when:
+        def config = [:]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('* --') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
+
     def 'should ignore unexpected param' () {
         given:
         def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()

--- a/plugins/nf-schema/src/testResources/nextflow_schema.json
+++ b/plugins/nf-schema/src/testResources/nextflow_schema.json
@@ -245,6 +245,12 @@
                     "hidden": true,
                     "fa_icon": "fas fa-bacon"
                 }
+            },
+            "patternProperties": {
+                "^pattern_[a-z]+$": {
+                    "type": "string",
+                    "description": "A pattern property parameter"
+                }
             }
         }
     },

--- a/plugins/nf-schema/src/testResources/nextflow_schema.json
+++ b/plugins/nf-schema/src/testResources/nextflow_schema.json
@@ -244,6 +244,12 @@
                     "description": "Run this workflow with Conda. You can also use '-profile conda' instead of providing this parameter.",
                     "hidden": true,
                     "fa_icon": "fas fa-bacon"
+                },
+                "testCamelCase": {
+                    "type": "string",
+                    "description": "A camelCase param",
+                    "hidden": true
+
                 }
             },
             "patternProperties": {


### PR DESCRIPTION
`patternProperties` were already supported by the plugin but previously due to the way we detected expected vs supplied params we did not correctly detect `patternProperties` supplied and this would cause a warning about invalid parameters (which could be an error if `failUnrecognised` was enabled).

This PR switches to using the annotations of the jsonschema validation result to look at which values actually got evaluated (and thus recognised). 

Due to needing the validation result object I did this in the `validateObject` method of our json schema validator class and just return an extra list value. This is simply ignored by samplesheet validation which does not account for this. Similarly it is not used if we validate a schema within a schema, but unrecognised parameter warning were never supplied there anyway. 

The work was a little messy in my opinion and I wonder if there is scope to break out the error parsing in the validator class to more functions. But that can happen in the future. 

I removed a check for `isCamelCaseBug` and it seems to have had no impact (no tests broken) so I am unclear if it was being used at all or what the use-case was and thus maybe we are missing an edge-case test. @mirpedrol do you have any insight on why we added that check?