### PR TITLE
Add a config option to limit the max amount of characters for a value shown in error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 1. Slow uniqueness check (> 2hrs for 100k samples) made 400x faster by switching from `findAll` to a `subMap` for isolating the required unique fields.
 2. `patternProperties` now has greater support, with no warnings about invalid parameters which actually match a pattern
+3. Added a new configuration option: `validation.maxValueLength` which sets the maximum length that a value in an error message can be. The default is set to 150 characters.
 
 ## Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 1. Slow uniqueness check (> 2hrs for 100k samples) made 400x faster by switching from `findAll` to a `subMap` for isolating the required unique fields.
 2. `patternProperties` now has greater support, with no warnings about invalid parameters which actually match a pattern
-3. Added a new configuration option: `validation.maxValueLength` which sets the maximum length that a value in an error message can be. The default is set to 150 characters.
+3. Added a new configuration option: `validation.maxErrValSize` which sets the maximum length that a value in an error message can be. The default is set to 150 characters.
 
 ## Changes
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -95,7 +95,7 @@ This option does exactly the same as `validation.ignoreParams`, but provides pip
 validation.defaultIgnoreParams = ["param1", "param2"] // default: []
 ```
 
-## maxValueLength
+## maxErrValSize
 
 Configure the maximum characters of a value that may be shown in an error message. It takes a whole number above or equal to `0`. A value will be truncated when it goes over the maximum amount of characters. See the below example where the limit is to 20 characters:
 
@@ -104,7 +104,7 @@ Configure the maximum characters of a value that may be shown in an error messag
 ```
 
 ```groovy
-validation.maxValueLength = 100 // default: 150
+validation.maxErrValSize = 100 // default: 150
 ```
 
 ## help

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -97,7 +97,7 @@ validation.defaultIgnoreParams = ["param1", "param2"] // default: []
 
 ## maxErrValSize
 
-Configure the maximum characters of a value that may be shown in an error message. It takes a whole number above or equal to `0`. A value will be truncated when it goes over the maximum amount of characters. See the below example where the limit is to 20 characters:
+Configure the maximum characters of a value that may be shown in an error message. It takes a whole number above or equal to `1`. A value will be truncated when it goes over the maximum amount of characters. See the below example where the limit is to 20 characters:
 
 ```
 * --test (abcdefghij...qrstuvwxyz): Value is [string] but should be [integer]

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -97,7 +97,7 @@ validation.defaultIgnoreParams = ["param1", "param2"] // default: []
 
 ## maxErrValSize
 
-Configure the maximum characters of a value that may be shown in an error message. It takes a whole number above or equal to `1`. A value will be truncated when it goes over the maximum amount of characters. 
+Configure the maximum characters of a value that may be shown in an error message. It takes a whole number above or equal to `1`. A value will be truncated when it goes over the maximum amount of characters.
 
 Setting this option to `-1` will allow any amount of characters for values.
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -95,6 +95,18 @@ This option does exactly the same as `validation.ignoreParams`, but provides pip
 validation.defaultIgnoreParams = ["param1", "param2"] // default: []
 ```
 
+## maxValueLength
+
+Configure the maximum characters of a value that may be shown in an error message. It takes a whole number above or equal to `0`. A value will be truncated when it goes over the maximum amount of characters. See the below example where the limit is to 20 characters:
+
+```
+* --test (abcdefghij...qrstuvwxyz): Value is [string] but should be [integer]
+```
+
+```groovy
+validation.maxValueLength = 100 // default: 150
+```
+
 ## help
 
 The `validation.help` config scope can be used to configure the creation of the help message.

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -97,7 +97,11 @@ validation.defaultIgnoreParams = ["param1", "param2"] // default: []
 
 ## maxErrValSize
 
-Configure the maximum characters of a value that may be shown in an error message. It takes a whole number above or equal to `1`. A value will be truncated when it goes over the maximum amount of characters. See the below example where the limit is to 20 characters:
+Configure the maximum characters of a value that may be shown in an error message. It takes a whole number above or equal to `1`. A value will be truncated when it goes over the maximum amount of characters. 
+
+Setting this option to `-1` will allow any amount of characters for values.
+
+See the below example where the limit is to 20 characters:
 
 ```
 * --test (abcdefghij...qrstuvwxyz): Value is [string] but should be [integer]

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -28,12 +28,12 @@ class ValidationConfig {
 
     ValidationConfig(Map map, Map params){
         def config = map ?: Collections.emptyMap()
-        lenientMode             = config.lenientMode                ?: false
-        monochromeLogs          = config.monochromeLogs             ?: false
-        failUnrecognisedParams  = config.failUnrecognisedParams     ?: false
-        failUnrecognisedHeaders = config.failUnrecognisedHeaders    ?: false
-        showHiddenParams        = config.showHiddenParams           ?: false
-        maxValueLength          = config.maxValueLength             ?: 150
+        lenientMode             = config.lenientMode                                    ?: false
+        monochromeLogs          = config.monochromeLogs                                 ?: false
+        failUnrecognisedParams  = config.failUnrecognisedParams                         ?: false
+        failUnrecognisedHeaders = config.failUnrecognisedHeaders                        ?: false
+        showHiddenParams        = config.showHiddenParams                               ?: false
+        maxValueLength          = config.maxValueLength && config.maxValueLength >= 0   ?: 150
         if(config.containsKey("showHiddenParams")) {
             log.warn("configuration option `validation.showHiddenParams` is deprecated, please use `validation.help.showHidden` or the `--showHidden` parameter instead")
         }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -20,7 +20,7 @@ class ValidationConfig {
     final public Boolean failUnrecognisedHeaders
     final public String  parametersSchema
     final public Boolean showHiddenParams
-    final public Integer maxErrValSize
+    final public Integer maxErrValSize = 150
     final public HelpConfig help
     final public SummaryConfig summary
 
@@ -33,7 +33,13 @@ class ValidationConfig {
         failUnrecognisedParams  = config.failUnrecognisedParams                         ?: false
         failUnrecognisedHeaders = config.failUnrecognisedHeaders                        ?: false
         showHiddenParams        = config.showHiddenParams                               ?: false
-        maxErrValSize           = config.maxErrValSize && config.maxErrValSize >= 1     ? config.maxErrValSize : 150
+        if(config.maxErrValSize != null) {
+            if(config.maxErrValSize >= 1 || config.maxErrValSize == -1) {
+                maxErrValSize = config.maxErrValSize
+            } else {
+                log.warn("`validation.maxErrValSize` needs to be a value above 0 or equal to -1, defaulting to ${maxErrValSize}")
+            }
+        }
         if(config.containsKey("showHiddenParams")) {
             log.warn("configuration option `validation.showHiddenParams` is deprecated, please use `validation.help.showHidden` or the `--showHidden` parameter instead")
         }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -20,6 +20,7 @@ class ValidationConfig {
     final public Boolean failUnrecognisedHeaders
     final public String  parametersSchema
     final public Boolean showHiddenParams
+    final public Integer maxValueLength
     final public HelpConfig help
     final public SummaryConfig summary
 
@@ -32,6 +33,7 @@ class ValidationConfig {
         failUnrecognisedParams  = config.failUnrecognisedParams     ?: false
         failUnrecognisedHeaders = config.failUnrecognisedHeaders    ?: false
         showHiddenParams        = config.showHiddenParams           ?: false
+        maxValueLength          = config.maxValueLength             ?: 150
         if(config.containsKey("showHiddenParams")) {
             log.warn("configuration option `validation.showHiddenParams` is deprecated, please use `validation.help.showHidden` or the `--showHidden` parameter instead")
         }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -20,7 +20,7 @@ class ValidationConfig {
     final public Boolean failUnrecognisedHeaders
     final public String  parametersSchema
     final public Boolean showHiddenParams
-    final public Integer maxValueLength
+    final public Integer maxErrValSize
     final public HelpConfig help
     final public SummaryConfig summary
 
@@ -33,7 +33,7 @@ class ValidationConfig {
         failUnrecognisedParams  = config.failUnrecognisedParams                         ?: false
         failUnrecognisedHeaders = config.failUnrecognisedHeaders                        ?: false
         showHiddenParams        = config.showHiddenParams                               ?: false
-        maxValueLength          = config.maxValueLength && config.maxValueLength >= 0   ? config.maxValueLength : 150
+        maxErrValSize          = config.maxErrValSize && config.maxErrValSize >= 0   ? config.maxErrValSize : 150
         if(config.containsKey("showHiddenParams")) {
             log.warn("configuration option `validation.showHiddenParams` is deprecated, please use `validation.help.showHidden` or the `--showHidden` parameter instead")
         }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -33,7 +33,7 @@ class ValidationConfig {
         failUnrecognisedParams  = config.failUnrecognisedParams                         ?: false
         failUnrecognisedHeaders = config.failUnrecognisedHeaders                        ?: false
         showHiddenParams        = config.showHiddenParams                               ?: false
-        maxValueLength          = config.maxValueLength && config.maxValueLength >= 0   ?: 150
+        maxValueLength          = config.maxValueLength && config.maxValueLength >= 0   ? config.maxValueLength : 150
         if(config.containsKey("showHiddenParams")) {
             log.warn("configuration option `validation.showHiddenParams` is deprecated, please use `validation.help.showHidden` or the `--showHidden` parameter instead")
         }

--- a/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/config/ValidationConfig.groovy
@@ -33,7 +33,7 @@ class ValidationConfig {
         failUnrecognisedParams  = config.failUnrecognisedParams                         ?: false
         failUnrecognisedHeaders = config.failUnrecognisedHeaders                        ?: false
         showHiddenParams        = config.showHiddenParams                               ?: false
-        maxErrValSize          = config.maxErrValSize && config.maxErrValSize >= 0   ? config.maxErrValSize : 150
+        maxErrValSize           = config.maxErrValSize && config.maxErrValSize >= 1     ? config.maxErrValSize : 150
         if(config.containsKey("showHiddenParams")) {
             log.warn("configuration option `validation.showHiddenParams` is deprecated, please use `validation.help.showHidden` or the `--showHidden` parameter instead")
         }

--- a/plugins/nf-schema/src/main/nextflow/validation/validators/JsonSchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/validators/JsonSchemaValidator.groovy
@@ -65,6 +65,9 @@ public class JsonSchemaValidator {
 
             def String instanceLocation = error.getInstanceLocation()
             def String value = getValueFromJsonPointer(instanceLocation, rawJson)
+            if(value.size() > config.maxValueLength) {
+                value = "${value[0..(config.maxValueLength/2-1)]}...${value[-config.maxValueLength/2..-1]}" as String
+            }
 
             // Get the custom errorMessage if there is one and the validation errors are not about the content of the file
             def String schemaLocation = error.getSchemaLocation().replaceFirst(/^[^#]+/, "")

--- a/plugins/nf-schema/src/main/nextflow/validation/validators/JsonSchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/validators/JsonSchemaValidator.groovy
@@ -65,8 +65,8 @@ public class JsonSchemaValidator {
 
             def String instanceLocation = error.getInstanceLocation()
             def String value = getValueFromJsonPointer(instanceLocation, rawJson)
-            if(value.size() > config.maxValueLength) {
-                value = "${value[0..(config.maxValueLength/2-1)]}...${value[-config.maxValueLength/2..-1]}" as String
+            if(value.size() > config.maxErrValSize) {
+                value = "${value[0..(config.maxErrValSize/2-1)]}...${value[-config.maxErrValSize/2..-1]}" as String
             }
 
             // Get the custom errorMessage if there is one and the validation errors are not about the content of the file

--- a/plugins/nf-schema/src/main/nextflow/validation/validators/JsonSchemaValidator.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/validators/JsonSchemaValidator.groovy
@@ -65,7 +65,7 @@ public class JsonSchemaValidator {
 
             def String instanceLocation = error.getInstanceLocation()
             def String value = getValueFromJsonPointer(instanceLocation, rawJson)
-            if(value.size() > config.maxErrValSize) {
+            if(config.maxErrValSize >= 1 && value.size() > config.maxErrValSize) {
                 value = "${value[0..(config.maxErrValSize/2-1)]}...${value[-config.maxErrValSize/2..-1]}" as String
             }
 

--- a/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
@@ -1400,4 +1400,30 @@ class ValidateParametersTest extends Dsl2Spec{
         !stdout
     }
 
+    def 'should truncate long values in errors' () {
+        given:
+        def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()
+        def SCRIPT = """
+            params.input = 'src/testResources/wrong_samplesheet_with_a_super_long_name.and_a_weird_extension'
+            params.outdir = 'src/testResources/testDir'
+            include { validateParameters } from 'plugin/nf-schema'
+            
+            validateParameters(parameters_schema: '$schema')
+        """
+
+        when:
+        def config = ["validation": [
+            "maxValueLength": 20
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('* --') ? it : null }
+
+        then:
+        def error = thrown(SchemaValidationException)
+        error.message.contains("* --input (src/testRe..._extension): \"src/testResources/wrong_samplesheet_with_a_super_long_name.and_a_weird_extension\" does not match regular expression [^\\S+\\.(csv|tsv|yaml|json)\$]")
+        !stdout
+    }
 }

--- a/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/ValidateParametersTest.groovy
@@ -1413,7 +1413,7 @@ class ValidateParametersTest extends Dsl2Spec{
 
         when:
         def config = ["validation": [
-            "maxValueLength": 20
+            "maxErrValSize": 20
         ]]
         def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
         def stdout = capture


### PR DESCRIPTION
Fixes #80 

This PR adds the `validation.maxValueLength` option that takes an integer (bigger than or equal to 0) as input and uses this to limit the amount of characters that a value can be in error messages.

Example:
with `validation.maxValueLength = 20`
```
* --test (abcdefghij...qrstuvwxyz): Value is [string] but should be [integer]
```
Where the original value is 26 characters long (`abcdefghijklmnopqrstuvwxyz`)

The default of this option is `150` which should prevent the loss of most data, but I'm of course open to discuss lowering or raising this default