### PR TITLE
Storing meta in a nested structure to avoid key collisions

### DIFF
--- a/plugins/nf-schema/src/test/nextflow/validation/SamplesheetConverterTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/SamplesheetConverterTest.groovy
@@ -459,7 +459,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
 
         then:
         noExceptionThrown()
-        stdout.contains("[[mapMeta:this is in a map, arrayMeta:[metaString45, metaString478], otherArrayMeta:[metaString45, metaString478], meta:metaValue, metaMap:[entry1:entry1String, entry2:12.56]], [[string1, string2], string3, 1, 1, ${getRootString()}/file1.txt], [string4, string5, string6], [[string7, string8], [string9, string10]], test]" as String)
+        stdout.contains("[[arrayMeta:[metaString45, metaString478], otherArrayMeta:[metaString45, metaString478], meta:metaValue, metaMap:[entry1:entry1String, entry2:12.56]], [[localMeta:this is in a map], [string1, string2], string3, 1, 1, ${getRootString()}/file1.txt], [string4, string5, string6], [[string7, string8], [string9, string10]], test]" as String)
     }
 
     def 'deeply nested samplesheet - JSON' () {
@@ -485,7 +485,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
 
         then:
         noExceptionThrown()
-        stdout.contains("[[mapMeta:this is in a map, arrayMeta:[metaString45, metaString478], otherArrayMeta:[metaString45, metaString478], meta:metaValue, metaMap:[entry1:entry1String, entry2:12.56]], [[string1, string2], string3, 1, 1, ${getRootString()}/file1.txt], [string4, string5, string6], [[string7, string8], [string9, string10]], test]" as String)
+        stdout.contains("[[arrayMeta:[metaString45, metaString478], otherArrayMeta:[metaString45, metaString478], meta:metaValue, metaMap:[entry1:entry1String, entry2:12.56]], [[localMeta:this is in a map], [string1, string2], string3, 1, 1, ${getRootString()}/file1.txt], [string4, string5, string6], [[string7, string8], [string9, string10]], test]" as String)
     }
 
     def 'samplesheetToList - String, String' () {
@@ -638,7 +638,7 @@ class SamplesheetConverterTest extends Dsl2Spec{
 
         then:
         noExceptionThrown()
-        stdout.contains("[[mapMeta:this is in a map, arrayMeta:[metaString45, metaString478], otherArrayMeta:[metaString45, metaString478], meta:metaValue, metaMap:[entry1:entry1String, entry2:12.56]], [[string1, string2], string3, 1, 1, ${getRootString()}/file1.txt], [string4, string5, string6], [[string7, string8], [string9, string10]], test]" as String)
+        stdout.contains("[[arrayMeta:[metaString45, metaString478], otherArrayMeta:[metaString45, metaString478], meta:metaValue, metaMap:[entry1:entry1String, entry2:12.56]], [[localMeta:this is in a map], [string1, string2], string3, 1, 1, ${getRootString()}/file1.txt], [string4, string5, string6], [[string7, string8], [string9, string10]], test]" as String)
 
     }
 }

--- a/plugins/nf-schema/src/testResources/samplesheet_schema_deeply_nested.json
+++ b/plugins/nf-schema/src/testResources/samplesheet_schema_deeply_nested.json
@@ -31,7 +31,7 @@
                     },
                     "mapMeta": {
                         "type": "string",
-                        "meta": "mapMeta"
+                        "meta": "localMeta"
                     }
                 }
             },

--- a/plugins/nf-schema/src/testResources/samplesheet_schema_deeply_nested_anyof.json
+++ b/plugins/nf-schema/src/testResources/samplesheet_schema_deeply_nested_anyof.json
@@ -31,7 +31,7 @@
                     },
                     "mapMeta": {
                         "type": "string",
-                        "meta": "mapMeta"
+                        "meta": "localMeta"
                     }
                 }
             },


### PR DESCRIPTION
Currently the `SamplesheetConverter` stores all meta fields in a single, class‐level map. But this can mix meta fields from different nesting levels and clobber keys when multiple nested objects share the same keys.

I’ve implemented some changes that keep meta fields at the correct nesting level to avoid collisions. This changes the expected output a little, so I’ve updated the tests accordingly. Is this refactoring something you’re interested in merging? If so, I can update the change log or adjust the PR as needed.

My use case puts some properties in an array. It would be preferable to include these in separate meta maps:

`input_schema.json`:

```
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "type": "array",
  "items": {
    "type": "object",
    "properties": {
      "patient_id": {
        "pattern": "^\\S+$",
        "errorMessage": "Patient id must be provided and must not contain whitespace",
        "meta": ["id", "patient_id"]
      },
      "run_id": {
        "pattern": "^\\S+$",
        "errorMessage": "Run id must be provided and must not contain whitespace",
        "meta": ["run_id"]
      },
      "test_sample": {
        "type": "object",
        "properties": {
          "uin": { "type": "string" },
          "reads": {
            "type": "array",
            "items": {
              "type": "object",
              "properties": {
                "id": { "meta": ["id"] },
                "cn": { "meta": ["cn"] },
                "ds": { "meta": ["ds"] },
                "dt": { "meta": ["dt"], "format": "date" },
                "lb": { "meta": ["lb"] },
                "pl": { "meta": ["pl"] },
                "pm": { "meta": ["pm"] },
                "pu": { "meta": ["pu"] },
                "sm": { "meta": ["sm"] },
                "r1": { "format": "file-path" },
                "r2": { "format": "file-path" }
              },
              "required": [
                "id", "r1", "r2"
              ]
            }
          }
        },
        "required": ["uin", "reads"]
      },
      "control_sample": {
        "type": "object",
        "properties": {
          "uin": { "type": "string" },
          "reads": {
            "type": "array",
            "items": {
              "type": "object",
              "properties": {
                "id": { "meta": ["id"] },
                "cn": { "meta": ["cn"] },
                "ds": { "meta": ["ds"] },
                "dt": { "meta": ["dt"], "format": "date" },
                "lb": { "meta": ["lb"] },
                "pl": { "meta": ["pl"] },
                "pm": { "meta": ["pm"] },
                "pu": { "meta": ["pu"] },
                "sm": { "meta": ["sm"] },
                "r1": { "format": "file-path" },
                "r2": { "format": "file-path" }
              },
              "required": [
                "id", "r1", "r2"
              ]
            }
          }
        },
        "required": ["uin", "reads"]
      }
    },
    "required": [
      "patient_id",
      "test_sample",
      "control_sample"
    ]
  }
}
```

`input.json`:

```
[
  {
    "patient_id": "PATIENT",
    "test_sample": {
      "uin": "20250101-0001-T",
      "reads": [
        {
          "id": "TEST-1",
          "dt": "2025-01-01",
          "pl": "ILLUMINA",
          "sm": "test",
          "r1": "/path/to/TEST_L001_R1_001.fastq.gz",
          "r2": "/path/to/TEST_L001_R2_001.fastq.gz"
        },
        {
          "id": "TEST-2",
          "dt": "2025-01-01",
          "pl": "ILLUMINA",
          "sm": "test",
          "r1": "/path/to/TEST_L002_R1_001.fastq.gz",
          "r2": "/path/to/TEST_L002_R2_001.fastq.gz"
        }
      ]
    },
    "control_sample": {
      "uin": "20250101-0001-N",
      "reads": [
        {
          "id": "CONTROL",
          "dt": "2025-01-01",
          "pl": "ILLUMINA",
          "sm": "control",
          "r1": "/path/to/CONTROL_L001_R1_001.fastq.gz",
          "r2": "/path/to/CONTROL_L001_R2_001.fastq.gz"
        }
      ]
    }
  }
]
```

`main.nf`

```
include { samplesheetToList } from 'plugin/nf-schema'

params.input = "test.json"
params.schema = "input_schema.json"

workflow {
    Channel.fromList(samplesheetToList(params.input, params.schema))
        .view()
}
```

output:

```
[[id:PATIENT, patient_id:PATIENT, run_id:[]], [20250101-0001-T, [[[id:TEST-1, cn:[], ds:[], dt:2025-01-01, lb:[], pl:ILLUMINA, pm:[], pu:[], sm:test], /path/to/TEST_L001_R1_001.fastq.gz, /path/to/TEST_L001_R2_001.fastq.gz], [[id:TEST-2, cn:[], ds:[], dt:2025-01-01, lb:[], pl:ILLUMINA, pm:[], pu:[], sm:test], /path/to/TEST_L002_R1_001.fastq.gz, /path/to/TEST_L002_R2_001.fastq.gz]]], [20250101-0001-N, [[[id:CONTROL, cn:[], ds:[], dt:2025-01-01, lb:[], pl:ILLUMINA, pm:[], pu:[], sm:control], /path/to/CONTROL_L001_R1_001.fastq.gz, /path/to/CONTROL_L001_R2_001.fastq.gz]]]]
```