### PR TITLE
Add a `validate` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Version 2.4.0dev
 
+## New features
+
+1. Added a new configuration option: `validation.maxErrValSize` which sets the maximum length that a value in an error message can be. The default is set to 150 characters.
+2. Added a new function: `validate()` that can be used to validate any data structure using a JSON schema.
+
 ## Bug fixes
 
 1. Move the unpinned version check to an observer. This makes sure the warning is always shown and not only when importing a function.
@@ -12,7 +17,6 @@
 
 1. Slow uniqueness check (> 2hrs for 100k samples) made 400x faster by switching from `findAll` to a `subMap` for isolating the required unique fields.
 2. `patternProperties` now has greater support, with no warnings about invalid parameters which actually match a pattern
-3. Added a new configuration option: `validation.maxErrValSize` which sets the maximum length that a value in an error message can be. The default is set to 150 characters.
 
 ## Changes
 

--- a/docs/validate/validate.md
+++ b/docs/validate/validate.md
@@ -1,0 +1,32 @@
+---
+title: Validate common data structures
+description: Function to validate common data structures
+---
+
+# Validate common data structures
+
+The `validate` function can be used to validate common data structures.
+
+```groovy
+include { validate } from 'plugin/nf-schema'
+
+validate(<input>, <schema>)
+```
+
+This function takes two positional arguments:
+
+1. The data that needs to be validated
+2. The path to the schema used to validate the input data
+
+The tested data structures are listed below, however more data structures might by supported too:
+
+- Maps
+- Lists
+- String
+- Integers
+- Booleans
+
+`validate` also has the following optional arguments:
+
+- `exitOnError`: Exit the pipeline on validation failure and show the error message. The function will output the errors when this option is set to `false` (default: `true`)
+  - `validate(<input>, <schema>, exitOnError:true|false)`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Parameter log: parameters/summary_log.md
       - Samplesheet parsing: samplesheets/samplesheetToList.md
       - Samplesheet examples: samplesheets/examples.md
+      - Other validation: validate/validate.md
   - Contributing:
       - contributing/setup.md
 

--- a/plugins/nf-schema/src/main/nextflow/validation/ValidationExtension.groovy
+++ b/plugins/nf-schema/src/main/nextflow/validation/ValidationExtension.groovy
@@ -138,7 +138,7 @@ class ValidationExtension extends PluginExtensionPoint {
         }
         def String schemaString = Files.readString( Path.of(getBasePath(session.baseDir.toString(), schema)) )
         def List<String> errors = validator.validateObj(jsonObj, schemaString)[0]
-        if(exitOnError) {
+        if(exitOnError && errors != []) {
             def colors = getLogColors(config.monochromeLogs)
             def String msg = "${colors.red}${errors.join('\n')}${colors.reset}\n"
             throw new SchemaValidationException(msg)

--- a/plugins/nf-schema/src/test/nextflow/validation/ValidateTest.groovy
+++ b/plugins/nf-schema/src/test/nextflow/validation/ValidateTest.groovy
@@ -1,0 +1,341 @@
+package nextflow.validation
+
+import java.nio.file.Path
+
+import nextflow.plugin.Plugins
+import nextflow.plugin.TestPluginDescriptorFinder
+import nextflow.plugin.TestPluginManager
+import nextflow.plugin.extension.PluginExtensionProvider
+import org.junit.Rule
+import org.pf4j.PluginDescriptorFinder
+import spock.lang.Shared
+import test.Dsl2Spec
+import test.OutputCapture
+import test.MockScriptRunner
+
+import nextflow.validation.exceptions.SchemaValidationException
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.jar.Manifest
+
+/**
+ * @author : nvnieuwk <nicolas.vannieuwkerke@ugent.be>
+ * @author : jorgeaguileraseqera
+ */
+class ValidateTest extends Dsl2Spec{
+
+    @Rule
+    OutputCapture capture = new OutputCapture()
+
+
+    @Shared String pluginsMode
+
+    Path root = Path.of('.').toAbsolutePath().normalize()
+    Path getRoot() { this.root }
+    String getRootString() { this.root.toString() }
+
+    def setup() {
+        // reset previous instances
+        PluginExtensionProvider.reset()
+        // this need to be set *before* the plugin manager class is created
+        pluginsMode = System.getProperty('pf4j.mode')
+        System.setProperty('pf4j.mode', 'dev')
+        // the plugin root should
+        def root = this.getRoot()
+        def manager = new TestPluginManager(root){
+            @Override
+            protected PluginDescriptorFinder createPluginDescriptorFinder() {
+                return new TestPluginDescriptorFinder(){
+                    @Override
+                    protected Manifest readManifestFromDirectory(Path pluginPath) {
+                        def manifestPath = getManifestPath(pluginPath)
+                        final input = Files.newInputStream(manifestPath)
+                        return new Manifest(input)
+                    }
+                    protected Path getManifestPath(Path pluginPath) {
+                        return pluginPath.resolve('build/resources/main/META-INF/MANIFEST.MF')
+                    }
+                }
+            }
+        }
+        Plugins.init(root, 'dev', manager)
+    }
+
+    def cleanup() {
+        Plugins.stop()
+        PluginExtensionProvider.reset()
+        pluginsMode ? System.setProperty('pf4j.mode',pluginsMode) : System.clearProperty('pf4j.mode')
+    }
+
+    def 'should validate a map - success' () {
+        given:
+        def SCRIPT = """
+            include { validate } from 'plugin/nf-schema'
+            
+            def input = [
+                this: [
+                    is: [
+                        so: [
+                            deep: true
+                        ]
+                    ]
+                ]
+            ]
+
+            validate(input, 'src/testResources/nextflow_schema_nested_parameters.json')
+        """
+
+        when:
+        def config = ["validation": [
+            "monochromeLogs": true
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('\\') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
+    def 'should validate a map - failure' () {
+        given:
+        def SCRIPT = """
+            include { validate } from 'plugin/nf-schema'
+            
+            def input = [
+                this: [
+                    is: [
+                        so: [
+                            deep: "a wrong string"
+                        ]
+                    ]
+                ]
+            ]
+
+            validate(input, 'src/testResources/nextflow_schema_nested_parameters.json')
+        """
+
+        when:
+        def config = ["validation": [
+            "monochromeLogs": true
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('\\') ? it : null }
+
+        then:
+        def error = thrown(SchemaValidationException)
+        error.message == "/this/is/so/deep (a wrong string): Value is [string] but should be [boolean]\n({\"this\":{\"is\":{\"so\":{\"deep\":\"a wrong string\"}}}}): Value does not match against the schemas at indexes [0]\n"
+        !stdout
+    }
+
+    def 'should validate a list - success' () {
+        given:
+        def SCRIPT = """
+            include { validate } from 'plugin/nf-schema'
+            
+            def input = ["value"]
+
+            validate(input, 'src/testResources/no_header_schema.json')
+        """
+
+        when:
+        def config = ["validation": [
+            "monochromeLogs": true
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('\\') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
+    def 'should validate a list - failure' () {
+        given:
+        def SCRIPT = """
+            include { validate } from 'plugin/nf-schema'
+            
+            def input = [12]
+
+            validate(input, 'src/testResources/no_header_schema.json')
+        """
+
+        when:
+        def config = ["validation": [
+            "monochromeLogs": true
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('\\') ? it : null }
+
+        then:
+        def error = thrown(SchemaValidationException)
+        error.message == "/0 (12): Value is [integer] but should be [string]\n"
+        !stdout
+    }
+
+    def 'should validate a string - success' () {
+        given:
+        def SCRIPT = """
+            include { validate } from 'plugin/nf-schema'
+            
+            def input = "value"
+
+            validate(input, 'src/testResources/string_schema.json')
+        """
+
+        when:
+        def config = ["validation": [
+            "monochromeLogs": true
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('\\') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
+    def 'should validate a string - failure' () {
+        given:
+        def SCRIPT = """
+            include { validate } from 'plugin/nf-schema'
+            
+            def input = 12
+
+            validate(input, 'src/testResources/string_schema.json')
+        """
+
+        when:
+        def config = ["validation": [
+            "monochromeLogs": true
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('\\') ? it : null }
+
+        then:
+        def error = thrown(SchemaValidationException)
+        error.message == "(12): Value is [integer] but should be [string]\n"
+        !stdout
+    }
+
+    def 'should validate a integer - success' () {
+        given:
+        def SCRIPT = """
+            include { validate } from 'plugin/nf-schema'
+            
+            def input = 12
+
+            validate(input, 'src/testResources/integer_schema.json')
+        """
+
+        when:
+        def config = ["validation": [
+            "monochromeLogs": true
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('\\') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
+    def 'should validate a integer - failure' () {
+        given:
+        def SCRIPT = """
+            include { validate } from 'plugin/nf-schema'
+            
+            def input = "value"
+
+            validate(input, 'src/testResources/integer_schema.json')
+        """
+
+        when:
+        def config = ["validation": [
+            "monochromeLogs": true
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('\\') ? it : null }
+
+        then:
+        def error = thrown(SchemaValidationException)
+        error.message == "(value): Value is [string] but should be [integer]\n"
+        !stdout
+    }
+
+    def 'should validate a boolean - success' () {
+        given:
+        def SCRIPT = """
+            include { validate } from 'plugin/nf-schema'
+            
+            def input = true
+
+            validate(input, 'src/testResources/boolean_schema.json')
+        """
+
+        when:
+        def config = ["validation": [
+            "monochromeLogs": true
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('\\') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
+    def 'should validate a boolean - failure' () {
+        given:
+        def SCRIPT = """
+            include { validate } from 'plugin/nf-schema'
+            
+            def input = "value"
+
+            validate(input, 'src/testResources/boolean_schema.json')
+        """
+
+        when:
+        def config = ["validation": [
+            "monochromeLogs": true
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('\\') ? it : null }
+
+        then:
+        def error = thrown(SchemaValidationException)
+        error.message == "(value): Value is [string] but should be [boolean]\n"
+        !stdout
+    }
+}

--- a/plugins/nf-schema/src/testResources/boolean_schema.json
+++ b/plugins/nf-schema/src/testResources/boolean_schema.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Schema for a boolean value",
+    "type": "boolean"
+}
+

--- a/plugins/nf-schema/src/testResources/integer_schema.json
+++ b/plugins/nf-schema/src/testResources/integer_schema.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Schema for a integer value",
+    "type": "integer"
+}
+

--- a/plugins/nf-schema/src/testResources/string_schema.json
+++ b/plugins/nf-schema/src/testResources/string_schema.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Schema for a string value",
+    "type": "string"
+}
+


### PR DESCRIPTION
This PR adds a new function that can be used to validate common data structures (like maps, lists, strings...) against a JSON schema