### PR TITLE
fix config validation for GString values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nextflow-io/nf-schema: Changelog
 
+# Version 2.4.1
+
+## Bug fixes
+
+1. Allow `GString` values for all configuration options that allow `String` values.
+
 # Version 2.4.0
 
 ## New features

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Declare the plugin in your Nextflow pipeline configuration file:
 
 ```groovy title="nextflow.config"
 plugins {
-  id 'nf-schema@2.4.0'
+  id 'nf-schema@2.4.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'com.sanctionco.jmail:jmail:1.6.3' // Needed for e-mail format validation
 }
 
-version = '2.4.0'
+version = '2.4.1'
 
 nextflowPlugin {
     nextflowVersion = '24.10.0'

--- a/src/main/groovy/nextflow/validation/config/HelpConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/HelpConfig.groovy
@@ -15,12 +15,12 @@ class HelpConfig {
     final public Boolean enabled = false
     final public Boolean showHidden = false
 
-    final public String showHiddenParameter = "showHidden"
-    final public String shortParameter = "help"
-    final public String fullParameter = "helpFull"
-    final public String beforeText = ""
-    final public String afterText = ""
-    final public String command = ""
+    final public CharSequence showHiddenParameter = "showHidden"
+    final public CharSequence shortParameter = "help"
+    final public CharSequence fullParameter = "helpFull"
+    final public CharSequence beforeText = ""
+    final public CharSequence afterText = ""
+    final public CharSequence command = ""
 
     HelpConfig(Map map, Map params, Boolean monochromeLogs, Boolean showHiddenParams) {
         def config = map ?: Collections.emptyMap()
@@ -37,7 +37,7 @@ class HelpConfig {
 
         // showHiddenParameter
         if(config.containsKey("showHiddenParameter")) {
-            if(config.showHiddenParameter instanceof String) {
+            if(config.showHiddenParameter instanceof CharSequence) {
                 showHiddenParameter = config.showHiddenParameter
                 log.debug("Set `validation.help.showHiddenParameter` to ${showHiddenParameter}")
             } else {
@@ -60,7 +60,7 @@ class HelpConfig {
 
         // shortParameter
         if(config.containsKey("shortParameter")) {
-            if(config.shortParameter instanceof String) {
+            if(config.shortParameter instanceof CharSequence) {
                 shortParameter = config.shortParameter
                 log.debug("Set `validation.help.shortParameter` to ${shortParameter}")
             } else {
@@ -70,7 +70,7 @@ class HelpConfig {
 
         // fullParameter
         if(config.containsKey("fullParameter")) {
-            if(config.fullParameter instanceof String) {
+            if(config.fullParameter instanceof CharSequence) {
                 fullParameter = config.fullParameter
                 log.debug("Set `validation.help.fullParameter` to ${fullParameter}")
             } else {
@@ -80,7 +80,7 @@ class HelpConfig {
 
         // beforeText
         if(config.containsKey("beforeText")) {
-            if(config.beforeText instanceof String) {
+            if(config.beforeText instanceof CharSequence) {
                 if(monochromeLogs) {
                     beforeText = config.beforeText
                 } else {
@@ -94,7 +94,7 @@ class HelpConfig {
 
         // afterText
         if(config.containsKey("afterText")) {
-            if(config.afterText instanceof String) {
+            if(config.afterText instanceof CharSequence) {
                 if(monochromeLogs) {
                     afterText = config.afterText
                 } else {
@@ -108,7 +108,7 @@ class HelpConfig {
 
         // command
         if(config.containsKey("command")) {
-            if(config.command instanceof String) {
+            if(config.command instanceof CharSequence) {
                 if(monochromeLogs) {
                     command = config.command
                 } else {

--- a/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
@@ -13,17 +13,17 @@ import static nextflow.validation.utils.Colors.removeColors
 
 @Slf4j
 class SummaryConfig {
-    final public String beforeText = ""
-    final public String afterText = ""
+    final public CharSequence beforeText = ""
+    final public CharSequence afterText = ""
 
-    final public Set<String> hideParams = []
+    final public Set<CharSequence> hideParams = []
 
     SummaryConfig(Map map, Boolean monochromeLogs) {
         def config = map ?: Collections.emptyMap()
 
         // beforeText
         if(config.containsKey("beforeText")) {
-            if(config.beforeText instanceof String) {
+            if(config.beforeText instanceof CharSequence) {
                 if(monochromeLogs) {
                     beforeText = config.beforeText
                 } else {
@@ -37,7 +37,7 @@ class SummaryConfig {
 
         // afterText
         if(config.containsKey("afterText")) {
-            if(config.afterText instanceof String) {
+            if(config.afterText instanceof CharSequence) {
                 if(monochromeLogs) {
                     afterText = config.afterText
                 } else {
@@ -51,7 +51,7 @@ class SummaryConfig {
 
         // hideParams
         if(config.containsKey("hideParams")) {
-            if(config.hideParams instanceof List<String>) {
+            if(config.hideParams instanceof List<CharSequence>) {
                 hideParams = config.hideParams
                 log.debug("Set `validation.summary.hideParams` to ${hideParams}")
             } else {

--- a/src/main/groovy/nextflow/validation/config/ValidationConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/ValidationConfig.groovy
@@ -22,9 +22,9 @@ class ValidationConfig {
 
     final public Integer maxErrValSize = 150
 
-    final public String  parametersSchema = "nextflow_schema.json"
+    final public CharSequence  parametersSchema = "nextflow_schema.json"
 
-    final public Set<String> ignoreParams = ["nf_test_output"] // Always ignore the `--nf_test_output` parameter to avoid warnings when running with nf-test
+    final public Set<CharSequence> ignoreParams = ["nf_test_output"] // Always ignore the `--nf_test_output` parameter to avoid warnings when running with nf-test
 
     final public HelpConfig help
 
@@ -96,7 +96,7 @@ class ValidationConfig {
 
         // parameterSchema
         if(config.containsKey("parametersSchema")) {
-            if(config.parametersSchema instanceof String) {
+            if(config.parametersSchema instanceof CharSequence) {
                 parametersSchema = config.parametersSchema
                 log.debug("Set `validation.parametersSchema` to ${parametersSchema}")
             } else {
@@ -106,7 +106,7 @@ class ValidationConfig {
 
         // ignoreParams
         if(config.containsKey("ignoreParams")) {
-            if(config.ignoreParams instanceof List<String>) {
+            if(config.ignoreParams instanceof List<CharSequence>) {
                 ignoreParams += config.ignoreParams
                 log.debug("Added the following parameters to the ignored parameters: ${config.ignoreParams}")
             } else {
@@ -116,7 +116,7 @@ class ValidationConfig {
 
         // defaultIgnoreParams
         if(config.containsKey("defaultIgnoreParams")) {
-            if(config.defaultIgnoreParams instanceof List<String>) {
+            if(config.defaultIgnoreParams instanceof List<CharSequence>) {
                 ignoreParams += config.defaultIgnoreParams
                 log.debug("Added the following parameters to the ignored parameters: ${config.defaultIgnoreParams}")
             } else {

--- a/src/test/groovy/nextflow/validation/ConfigTest.groovy
+++ b/src/test/groovy/nextflow/validation/ConfigTest.groovy
@@ -1,0 +1,162 @@
+package nextflow.validation
+
+import java.nio.file.Path
+
+import nextflow.plugin.Plugins
+import nextflow.plugin.TestPluginDescriptorFinder
+import nextflow.plugin.TestPluginManager
+import nextflow.plugin.extension.PluginExtensionProvider
+import org.pf4j.PluginDescriptorFinder
+import nextflow.Session
+import spock.lang.Specification
+import spock.lang.Shared
+import org.slf4j.Logger
+import org.junit.Rule
+import test.Dsl2Spec
+import test.OutputCapture
+
+import nextflow.validation.config.ValidationConfig
+
+/**
+ * @author : nvnieuwk <nicolas.vannieuwkerke@ugent.be>
+ */
+class ConfigTest extends Dsl2Spec{
+
+    @Rule
+    OutputCapture capture = new OutputCapture()
+
+    @Shared String pluginsMode
+
+    Path root = Path.of('.').toAbsolutePath().normalize()
+    Path getRoot() { this.root }
+    String getRootString() { this.root.toString() }
+
+    private Session session
+
+    def setup() {
+        session = Mock(Session)
+        session.getBaseDir() >> getRoot()
+    }
+
+    def 'test valid config' () {
+        given:
+        def config = [
+            lenientMode: true,
+            monochromeLogs: true,
+            failUnrecognisedParams: true,
+            failUnrecognisedHeaders: true,
+            maxErrValSize: 20,
+            parametersSchema: 'src/testResources/nextflow_schema.json',
+            ignoreParams: ['some_random_param'],
+            help: [
+                enabled: true,
+                showHidden: true,
+                showHiddenParameter: 'stopHiding',
+                shortParameter: 'short',
+                fullParameter: 'full',
+                beforeText: 'before',
+                afterText: 'after',
+                command: 'command'
+            ],
+            summary: [
+                beforeText: 'before',
+                afterText: 'after',
+                hideParams: ['some_random_param'],
+            ]
+        ]
+        def params = [:]
+
+        when:
+        new ValidationConfig(config, params)
+        def stdout = capture
+            .toString()
+            .readLines()
+            .findResults { it.contains('WARN') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
+    def 'test valid config - GStrings' () {
+        given:
+        def randomString = 'randomString'
+        def config = [
+            lenientMode: true,
+            monochromeLogs: true,
+            failUnrecognisedParams: true,
+            failUnrecognisedHeaders: true,
+            maxErrValSize: 20,
+            parametersSchema: "${randomString}",
+            ignoreParams: ["${randomString}"],
+            help: [
+                enabled: true,
+                showHidden: true,
+                showHiddenParameter: "${randomString}",
+                shortParameter: "${randomString}",
+                fullParameter: "${randomString}",
+                beforeText: "${randomString}",
+                afterText: "${randomString}",
+                command: "${randomString}"
+            ],
+            summary: [
+                beforeText: "${randomString}",
+                afterText: "${randomString}",
+                hideParams: ["${randomString}"],
+            ]
+        ]
+        def params = [:]
+
+        when:
+        new ValidationConfig(config, params)
+        def stdout = capture
+            .toString()
+            .readLines()
+            .findResults { it.contains('WARN') ? it : null }
+
+        then:
+        noExceptionThrown()
+        !stdout
+    }
+
+    def 'test invalid config' () {
+        given:
+        def config = [
+            lenientMode: 'notABoolean',
+            monochromeLogs: 12,
+            failUnrecognisedParams: 'notABoolean',
+            failUnrecognisedHeaders: 'notABoolean',
+            showHiddenParams: 'notABoolean',
+            maxErrValSize: ["notAnInteger"],
+            parametersSchema: 42,
+            ignoreParams: true,
+            help: [
+                enabled: 'notABoolean',
+                showHidden: 'notABoolean',
+                showHiddenParameter: 123456789,
+                shortParameter: false,
+                fullParameter: [im:'a_map'],
+                beforeText: true,
+                afterText: ['im','a','list'],
+                command: 0
+            ],
+            summary: [
+                beforeText: 63,
+                afterText: false,
+                hideParams: 'randomString',
+            ]
+        ]
+        def params = [:]
+
+        when:
+        new ValidationConfig(config, params)
+        def stdout = capture
+            .toString()
+            .readLines()
+            .findResults { it.contains('WARN') ? it : null }
+
+        then:
+        noExceptionThrown()
+        stdout
+    }
+}


### PR DESCRIPTION
This PR fixes an issue in `2.4.0` that would not correctly recognize `GString`s as valid inputs for the `String` config options.