### PR TITLE
Correctly ignore nested params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # nextflow-io/nf-schema: Changelog
 
+# Version 2.4.2
+
+## Bug fixes
+
+1. `validateParameters` should now correctly ignore nested parameters given in the `validation.ignoreParams` and the `validation.defaultIgnoreParams` configuration options.
+
 # Version 2.4.1
 
 ## Bug fixes

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'com.sanctionco.jmail:jmail:1.6.3' // Needed for e-mail format validation
 }
 
-version = '2.4.1'
+version = '2.4.2'
 
 nextflowPlugin {
     nextflowVersion = '24.10.0'

--- a/src/main/groovy/nextflow/validation/parameters/ParameterValidator.groovy
+++ b/src/main/groovy/nextflow/validation/parameters/ParameterValidator.groovy
@@ -150,10 +150,11 @@ class ParameterValidator {
         // Check for nextflow core params and unexpected params
         //=====================================================================//
         unevaluatedParams.each{ param ->
+            def String dotParam = param.replaceAll("/", ".")
             if (NF_OPTIONS.contains(param)) {
                 errors << "You used a core Nextflow option with two hyphens: '--${param}'. Please resubmit with '-${param}'".toString()
             }
-            else if (!config.ignoreParams.any { param.startsWith(it) } ) {
+            else if (!config.ignoreParams.any { dotParam == it || dotParam.startsWith(it + ".") } ) { // Check if an ignore param is present
                 def String text = "* --${param.replaceAll("/", ".")}: ${getValueFromJsonPointer("/"+param, paramsJSON)}".toString()
                 if(config.failUnrecognisedParams) {
                     errors << text

--- a/src/main/groovy/nextflow/validation/parameters/ParameterValidator.groovy
+++ b/src/main/groovy/nextflow/validation/parameters/ParameterValidator.groovy
@@ -153,10 +153,13 @@ class ParameterValidator {
             if (NF_OPTIONS.contains(param)) {
                 errors << "You used a core Nextflow option with two hyphens: '--${param}'. Please resubmit with '-${param}'".toString()
             }
-            else if (config.failUnrecognisedParams && !config.ignoreParams.contains(param)) {
-                errors << "* --${param.replaceAll("/", ".")}: ${getValueFromJsonPointer("/"+param, paramsJSON)}".toString()
-            } else if (!config.ignoreParams.contains(param)) {
-                warnings << "* --${param.replaceAll("/", ".")}: ${getValueFromJsonPointer("/"+param, paramsJSON)}".toString()
+            else if (!config.ignoreParams.any { param.startsWith(it) } ) {
+                def String text = "* --${param.replaceAll("/", ".")}: ${getValueFromJsonPointer("/"+param, paramsJSON)}".toString()
+                if(config.failUnrecognisedParams) {
+                    errors << text
+                } else {
+                    warnings << text
+                }
             }
         }
         // check for warnings

--- a/src/test/groovy/nextflow/validation/ValidateParametersTest.groovy
+++ b/src/test/groovy/nextflow/validation/ValidateParametersTest.groovy
@@ -1443,6 +1443,7 @@ class ValidateParametersTest extends Dsl2Spec{
             params.genome = [
                 "test": "test"
             ]
+            params.genomebutlonger = true
             params.testing = "test"
             include { validateParameters } from 'plugin/nf-schema'
             
@@ -1461,6 +1462,6 @@ class ValidateParametersTest extends Dsl2Spec{
 
         then:
         noExceptionThrown()
-        stdout == ["* --testing: test"]
+        stdout == ["* --testing: test", "* --genomebutlonger: true"]
     }
 }

--- a/src/test/groovy/nextflow/validation/ValidateParametersTest.groovy
+++ b/src/test/groovy/nextflow/validation/ValidateParametersTest.groovy
@@ -1435,4 +1435,32 @@ class ValidateParametersTest extends Dsl2Spec{
         error.message.contains("* --input (src/testRe..._extension): \"src/testResources/wrong_samplesheet_with_a_super_long_name.and_a_weird_extension\" does not match regular expression [^\\S+\\.(csv|tsv|yaml|json)\$]")
         !stdout
     }
+
+    def 'should correctly detect invalid parameters' () {
+        given:
+        def schema = Path.of('src/testResources/nextflow_schema_no_type.json').toAbsolutePath().toString()
+        def SCRIPT = """
+            params.genome = [
+                "test": "test"
+            ]
+            params.testing = "test"
+            include { validateParameters } from 'plugin/nf-schema'
+            
+            validateParameters(parameters_schema: '$schema')
+        """
+
+        when:
+        def config = ["validation": [
+            "defaultIgnoreParams": [ "genome" ]
+        ]]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.contains('WARN nextflow.validation.SchemaValidator') || it.startsWith('* --') ? it : null }
+
+        then:
+        noExceptionThrown()
+        stdout == ["* --testing: test"]
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where unrecognized nested parameters weren't correctly ignored.

Example:

config:
```groovy
validation.defaultIgnoreParams = [ "genomes" ]
```

This would not correctly catch all parameters inside of the `genomes` map and would show a very big warning at the start of the pipeline run