### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Or enable the creation of the help message (using `--help`) in the configuration
 ```groovy title="nextflow.config"
 validation {
   help {
-    enabled: true
+    enabled = true
   }
 }
 ```


### PR DESCRIPTION
The example for help seems to be wrong
enabled: true -> enabled = true