### PR TITLE
Sanitize CSV and TSV files to prevent empty header column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 1. The plugin now properly validates cloud storage files instead of skipping them. Exotic errors will be added to the error messages instead of failing the validation outright.
 2. Migrated to the new observer class in Nextflow 25.04.0
 
+## Bug fixes
+
+1. CSV and TSV files with trailing commas or tabs will now be properly sanitized. This fixes issues with CSV and TSV files that contained empty header columns.
+
 # Version 2.4.2
 
 ## Bug fixes

--- a/src/main/groovy/nextflow/validation/help/HelpObserver.groovy
+++ b/src/main/groovy/nextflow/validation/help/HelpObserver.groovy
@@ -3,7 +3,7 @@ package nextflow.validation.help
 import groovy.util.logging.Slf4j
 
 import nextflow.processor.TaskHandler
-import nextflow.trace.TraceObserver
+import nextflow.trace.TraceObserverV2
 import nextflow.trace.TraceRecord
 import nextflow.Session
 
@@ -11,7 +11,7 @@ import nextflow.validation.help.HelpMessageCreator
 import nextflow.validation.config.ValidationConfig
 
 @Slf4j
-class HelpObserver implements TraceObserver {
+class HelpObserver implements TraceObserverV2 {
     
     @Override
     void onFlowCreate(Session session) {

--- a/src/test/groovy/nextflow/validation/SamplesheetConverterTest.groovy
+++ b/src/test/groovy/nextflow/validation/SamplesheetConverterTest.groovy
@@ -641,4 +641,52 @@ class SamplesheetConverterTest extends Dsl2Spec{
         stdout.contains("[[mapMeta:this is in a map, arrayMeta:[metaString45, metaString478], otherArrayMeta:[metaString45, metaString478], meta:metaValue, metaMap:[entry1:entry1String, entry2:12.56]], [[string1, string2], string3, 1, 1, ${getRootString()}/file1.txt], [string4, string5, string6], [[string7, string8], [string9, string10]], test]" as String)
 
     }
+
+    def 'samplesheetToList - correctly sanitize empty header columns CSV' () {
+        given:
+        def SCRIPT_TEXT = '''
+            include { samplesheetToList } from 'plugin/nf-schema'
+
+            workflow {
+                Channel.fromList(samplesheetToList("src/testResources/samplesheet_empty_header_column.csv", "src/testResources/no_meta_schema.json")).view()       
+            }
+
+        '''
+
+        when:
+        dsl_eval(SCRIPT_TEXT)
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.startsWith('[') ? it : null }
+
+        then:
+        noExceptionThrown()
+        stdout.contains("[file1.txt, file2.txt]")
+
+    }
+
+    def 'samplesheetToList - correctly sanitize empty header columns TSV' () {
+        given:
+        def SCRIPT_TEXT = '''
+            include { samplesheetToList } from 'plugin/nf-schema'
+
+            workflow {
+                Channel.fromList(samplesheetToList("src/testResources/samplesheet_empty_header_column.tsv", "src/testResources/no_meta_schema.json")).view()       
+            }
+
+        '''
+
+        when:
+        dsl_eval(SCRIPT_TEXT)
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.startsWith('[') ? it : null }
+
+        then:
+        noExceptionThrown()
+        stdout.contains("[file1.txt, file2.txt]")
+
+    }
 }

--- a/src/testResources/samplesheet_empty_header_column.csv
+++ b/src/testResources/samplesheet_empty_header_column.csv
@@ -1,0 +1,2 @@
+input1,input2,
+file1.txt,file2.txt,

--- a/src/testResources/samplesheet_empty_header_column.tsv
+++ b/src/testResources/samplesheet_empty_header_column.tsv
@@ -1,0 +1,2 @@
+input1	input2	
+file1.txt	file2.txt	


### PR DESCRIPTION
Fixes #150 

This update checks if the header of the CSV and TSV file ends with an empty header field and removes that field in that case. This prevents an `"Empty header column"` error caused by `.splitCsv()`