### PR TITLE
Revive the `paramsHelp` function for the new strict config syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 1. The plugin now properly validates cloud storage files instead of skipping them. Exotic errors will be added to the error messages instead of failing the validation outright.
 2. Migrated to the new observer class in Nextflow 25.04.0
+3. Rework the deprecated `paramsHelp()` function to allow pipeline developers a fully fledged alternative to the help messages created via the configuration options. This change enables the use of dynamic help message with the strict configuration syntax introduced in Nextflow 25.04.0.
 
 ## Bug fixes
 

--- a/docs/parameters/help_text.md
+++ b/docs/parameters/help_text.md
@@ -165,18 +165,17 @@ If you prefer, you can disable these by setting the `validation.monochromeLogs` 
 
 ## `paramsHelp()`
 
-!!! deprecated
-
-    This function has been deprecated in v2.1.0. Use the [help configuration](#configure-help-message) instead
-
 This function returns a help message with the command to run a pipeline and the available parameters.
 Pass it to `log.info` to print in the terminal.
 
-It accepts three arguments:
+The function takes one optional positional argument, which can be a parameter name to get the help message for. Additionally, it can take a couple of options to customize the help message:
 
-1. An example command, typically used to run the pipeline, to be included in the help string
-2. An option to set the file name of a Nextflow Schema file: `parameters_schema: <schema.json>` (Default: `nextflow_schema.json`)
-3. An option to hide the deprecation warning: `hideWarning: <true/false>` (Default: `false`)
+- `parametersSchema`: Path to the JSON schema to get the help message from. Defaults to the schema defined in the `validation.parametersSchema` configuration option (which is `nextflow_schema.json` by default).
+- `beforeText`: Text to print before the help message. Defaults to the `validation.help.beforeText` configuration option.
+- `afterText`: Text to print after the help message. Defaults to the `validation.help.afterText` configuration option.
+- `command`: Command to print before the help message. Defaults to the `validation.help.command` configuration option.
+- `showHidden`: Whether to show hidden parameters in the help message. Defaults to `false`.
+- `fullHelp`: Whether to show the full help message (including all parameters, even those that are not top-level). Defaults to `false`.
 
 !!! Note
 
@@ -203,10 +202,16 @@ Typical usage:
     --8<-- "examples/paramsHelp/pipeline/nextflow_schema.json"
     ```
 
-Output:
+Output with `--help`:
 
 ```
 --8<-- "examples/paramsHelp/log.txt"
+```
+
+Output with `--help outdir`:
+
+```
+--8<-- "examples/paramsHelp/log_outdir.txt"
 ```
 
 !!! warning

--- a/examples/paramsHelp/log.txt
+++ b/examples/paramsHelp/log.txt
@@ -1,12 +1,13 @@
-N E X T F L O W  ~  version 23.04.1
-Launching `pipeline/main.nf` [infallible_turing] DSL2 - revision: 8bf4c8d053
+Launching `examples/paramsHelp/pipeline/main.nf` [deadly_turing] DSL2 - revision: 5c681b32ca
 
-Typical pipeline command:
+This is a help message for the pipeline.Typical pipeline command:
 
-  nextflow run my_pipeline --input input_file.csv
+  nextflow run main.nf
+
 
 Input/output options
-  --input  [string]  Path to comma-separated file containing information about the samples in the experiment.
-  --outdir [string]  The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.
-
+  --input      [string]  Path to comma-separated file containing information about the samples in the experiment. 
+  --outdir     [string]  The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure. 
+  --help       [boolean] Show the help message for the pipeline. [default: false] 
 ------------------------------------------------------
+Done with the help message.

--- a/examples/paramsHelp/log_outdir.txt
+++ b/examples/paramsHelp/log_outdir.txt
@@ -1,12 +1,13 @@
-N E X T F L O W  ~  version 23.04.1
-Launching `pipeline/main.nf` [exotic_rutherford] DSL2 - revision: 8bf4c8d053
+Launching `examples/paramsHelp/pipeline/main.nf` [curious_cori] DSL2 - revision: 5c681b32ca
 
-Typical pipeline command:
+This is a help message for the pipeline.Typical pipeline command:
 
-  nextflow run my_pipeline --input input_file.csv
+  nextflow run main.nf
 
---outdir
-    type       : string
-    format     : directory-path
-    description: The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.
+
+Input/output options
+  --input      [string]  Path to comma-separated file containing information about the samples in the experiment. 
+  --outdir     [string]  The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure. 
+  --help       [boolean] Show the help message for the pipeline. [default: false] 
 ------------------------------------------------------
+Done with the help message.

--- a/examples/paramsHelp/pipeline/main.nf
+++ b/examples/paramsHelp/pipeline/main.nf
@@ -1,6 +1,12 @@
 include { paramsHelp } from 'plugin/nf-schema'
 
-if (params.help) {
-    log.info paramsHelp("nextflow run my_pipeline --input input_file.csv")
-    exit 0
+workflow {
+    if (params.help) {
+        log.info paramsHelp(
+            beforeText: "This is a help message for the pipeline.",
+            afterText: "Done with the help message.",
+            command: "nextflow run main.nf",
+        )
+        exit 0
+    }
 }

--- a/examples/paramsHelp/pipeline/nextflow.config
+++ b/examples/paramsHelp/pipeline/nextflow.config
@@ -1,8 +1,9 @@
 plugins {
-  id 'nf-schema@2.0.0'
+  id 'nf-schema@2.5.0'
 }
 
 params {
   input = "samplesheet.csv"
   outdir = "results"
+  help = false // Set to true to see the help message
 }

--- a/examples/paramsHelp/pipeline/nextflow_schema.json
+++ b/examples/paramsHelp/pipeline/nextflow_schema.json
@@ -27,6 +27,13 @@
                     "format": "directory-path",
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
+                },
+                "help": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Show the help message for the pipeline.",
+                    "fa_icon": "fas fa-question-circle",
+                    "help_text": "If set to `true`, the pipeline will print a help message with the command to run it and the available parameters. This is useful for users who want to know how to run the pipeline and what parameters are available."
                 }
             }
         }

--- a/src/main/groovy/nextflow/validation/ValidationExtension.groovy
+++ b/src/main/groovy/nextflow/validation/ValidationExtension.groovy
@@ -167,6 +167,7 @@ class ValidationExtension extends PluginExtensionPoint {
 
         // Adapt config options with function options
         config.parametersSchema = options.get('parameters_schema', config.get("parametersSchema", "nextflow_schema.json")) as String
+        config.help = config.help ?: [:]
         config.help.enabled = true
         config.help.beforeText = options.get('beforeText', config.help.get("beforeText", "")) as String
         config.help.afterText = options.get('afterText', config.help.get("afterText", "")) as String

--- a/src/main/groovy/nextflow/validation/ValidationExtension.groovy
+++ b/src/main/groovy/nextflow/validation/ValidationExtension.groovy
@@ -151,34 +151,46 @@ class ValidationExtension extends PluginExtensionPoint {
     //
     @Function
     public String paramsHelp(
-        Map options = [:],
-        String command
+        final Map options = [:]
     ) {
-        if (!options.containsKey("hideWarning") || options.hideWarning == false) {
-            log.warn("""
-Using `paramsHelp()` is not recommended. Check out the help message migration guide: https://nextflow-io.github.io/nf-schema/latest/migration_guide/#updating-the-help-message
-If you intended to use this function, please add the following option to the input of the function:
-    `hideWarning: true`
+        return paramsHelp(options, "")
+    }
 
-Please contact the pipeline maintainer(s) if you see this warning as a user.
-            """)
-        }
-
+    @Function
+    public String paramsHelp(
+        final Map options = [:],
+        final String parameter
+    ) {
+        log.debug "Generating help message with options: ${options}"
         def Map params = session.params
-        def Map validationConfig = (Map)session.config.navigate("validation") ?: [:]
-        validationConfig.parametersSchema = options.containsKey('parameters_schema') ? options.parameters_schema as String : validationConfig.parametersSchema
-        validationConfig.help = (Map)(validationConfig.help ?: [:]) + [command: command, beforeText: "", afterText: ""]
-        def ValidationConfig copyConfig = new ValidationConfig(validationConfig, params)
-        def HelpMessageCreator helpCreator = new HelpMessageCreator(copyConfig, session)
+        def Map config = session.config.navigate("validation") ?: [:]
+
+        // Adapt config options with function options
+        config.parametersSchema = options.get('parameters_schema', config.get("parametersSchema", "nextflow_schema.json")) as String
+        config.help.enabled = true
+        config.help.beforeText = options.get('beforeText', config.help.get("beforeText", "")) as String
+        config.help.afterText = options.get('afterText', config.help.get("afterText", "")) as String
+        config.help.command = options.get('command', config.help.get("command", "")) as String
+        config.help.showHidden = options.get('showHidden', false) as Boolean
+
+        // Get function logic options
+        def Boolean fullHelp = options.get('fullHelp') as Boolean ?: false
+
+        // Generate the new help config
+        def final ValidationConfig functionConfig = new ValidationConfig(config, params)
+
+        // Create the help message
+        def HelpMessageCreator helpCreator = new HelpMessageCreator(functionConfig, session)
         def String help = helpCreator.getBeforeText()
-        def List<String> helpBodyLines = helpCreator.getShortMessage(params.help && params.help instanceof String ? params.help : "").readLines()
-        help += helpBodyLines.findAll {
+        def String helpBodyLines = fullHelp ? helpCreator.getFullMessage() : helpCreator.getShortMessage(parameter)
+        help += helpBodyLines.readLines().findAll {
             // Remove added ungrouped help parameters
-            !it.startsWith("--${copyConfig.help.shortParameter}") && 
-            !it.startsWith("--${copyConfig.help.fullParameter}") && 
-            !it.startsWith("--${copyConfig.help.showHiddenParameter}")
+            !it.startsWith("--${functionConfig.help.shortParameter}") && 
+            !it.startsWith("--${functionConfig.help.fullParameter}") && 
+            !it.startsWith("--${functionConfig.help.showHiddenParameter}")
         }.join("\n")
         help += helpCreator.getAfterText()
+        log.debug "Done generating help message"
         return help
     }
 

--- a/src/main/groovy/nextflow/validation/config/HelpConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/HelpConfig.groovy
@@ -76,7 +76,7 @@ class HelpConfig implements ConfigScope {
 
         // showHidden
         if(params.containsKey(showHiddenParameter) || config.containsKey("showHidden")) {
-            if(params.get(showHiddenParameter) instanceof Boolean) {
+            if(params.containsKey(showHiddenParameter) && params.get(showHiddenParameter) instanceof Boolean) {
                 showHidden = params.get(showHiddenParameter)
                 log.debug("Set `validation.help.showHidden` to ${showHidden} (Due to --${showHiddenParameter})")
             } else if(config.showHidden instanceof Boolean) {


### PR DESCRIPTION
Fixes #117 

Revive and upgrade the `paramsHelp` function to have way to print the help message that's compatible with the new strict config syntax