### PR TITLE
Set monochromeLogs according to ansi log settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. The plugin now properly validates cloud storage files instead of skipping them. Exotic errors will be added to the error messages instead of failing the validation outright.
 2. Migrated to the new observer class in Nextflow 25.04.0
 3. Rework the deprecated `paramsHelp()` function to allow pipeline developers a fully fledged alternative to the help messages created via the configuration options. This change enables the use of dynamic help message with the strict configuration syntax introduced in Nextflow 25.04.0.
+4. The ANSI log setting of Nextflow is now used to determine whether or not the log should be monochrome. This setting will take priority over the `validation.monochromeLogs` configuration option.
 
 ## Bug fixes
 

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -32,7 +32,7 @@ This option can either be a path relative to the root of the pipeline directory 
 
 ## monochromeLogs
 
-This option can be used to turn of the colored logs from nf-validation. This can be useful if you run a Nextflow pipeline in an environment that doesn't support colored logging.
+This option can be used to turn of the colored logs from nf-schema. This can be useful if you run a Nextflow pipeline in an environment that doesn't support colored logging. This option will automatically be set to `true` when ANSI logging is disabled in Nextflow.
 
 ```groovy
 validation.monochromeLogs = <true|false> // default: false

--- a/src/main/groovy/nextflow/validation/ValidationExtension.groovy
+++ b/src/main/groovy/nextflow/validation/ValidationExtension.groovy
@@ -42,10 +42,7 @@ class ValidationExtension extends PluginExtensionPoint {
     @Override
     protected void init(Session session) {
         this.session = session
-
-        // Help message logic
-        def Map params = (Map)session.params ?: [:]
-        config = new ValidationConfig(session?.config?.navigate('validation') as Map, params)
+        config = new ValidationConfig(session?.config?.navigate('validation') as Map, session)
 
     }
 
@@ -162,7 +159,6 @@ class ValidationExtension extends PluginExtensionPoint {
         final String parameter
     ) {
         log.debug "Generating help message with options: ${options}"
-        def Map params = session.params
         def Map config = session.config.navigate("validation") ?: [:]
 
         // Adapt config options with function options
@@ -178,7 +174,7 @@ class ValidationExtension extends PluginExtensionPoint {
         def Boolean fullHelp = options.get('fullHelp') as Boolean ?: false
 
         // Generate the new help config
-        def final ValidationConfig functionConfig = new ValidationConfig(config, params)
+        def final ValidationConfig functionConfig = new ValidationConfig(config, session)
 
         // Create the help message
         def HelpMessageCreator helpCreator = new HelpMessageCreator(functionConfig, session)

--- a/src/main/groovy/nextflow/validation/config/HelpConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/HelpConfig.groovy
@@ -120,9 +120,9 @@ class HelpConfig implements ConfigScope {
         if(config.containsKey("beforeText")) {
             if(config.beforeText instanceof CharSequence) {
                 if(monochromeLogs) {
-                    beforeText = config.beforeText
-                } else {
                     beforeText = removeColors(config.beforeText)
+                } else {
+                    beforeText = config.beforeText
                 }
                 log.debug("Set `validation.help.beforeText` to ${beforeText}")
             } else {
@@ -134,9 +134,9 @@ class HelpConfig implements ConfigScope {
         if(config.containsKey("afterText")) {
             if(config.afterText instanceof CharSequence) {
                 if(monochromeLogs) {
-                    afterText = config.afterText
-                } else {
                     afterText = removeColors(config.afterText)
+                } else {
+                    afterText = config.afterText
                 }
                 log.debug("Set `validation.help.afterText` to ${afterText}")
             } else {

--- a/src/main/groovy/nextflow/validation/config/ValidationConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/ValidationConfig.groovy
@@ -4,6 +4,7 @@ import groovy.util.logging.Slf4j
 
 import nextflow.validation.exceptions.SchemaValidationException
 
+import nextflow.Session
 import nextflow.config.schema.ConfigOption
 import nextflow.config.schema.ConfigScope
 import nextflow.config.schema.ScopeName
@@ -68,8 +69,9 @@ class ValidationConfig implements ConfigScope {
     // Keep the no-arg constructor in order to be able to use the `@ConfigOption` annotation
     ValidationConfig(){}
 
-    ValidationConfig(Map map, Map params){
+    ValidationConfig(Map map, Session session){
         def config = map ?: Collections.emptyMap()
+        def params = (Map)session.params ?: [:]
 
         // lenientMode
         if(config.containsKey("lenientMode")) {
@@ -82,8 +84,12 @@ class ValidationConfig implements ConfigScope {
         }
 
         // monochromeLogs
-        if(config.containsKey("monochromeLogs")) {
-            if(config.monochromeLogs instanceof Boolean) {
+        def ansiLog = session?.ansiLog ?: false
+        if(config.containsKey("monochromeLogs") || !ansiLog) {
+            if(!ansiLog) {
+                monochromeLogs = !ansiLog
+                log.debug("Set `validation.monochromeLogs` to ${monochromeLogs} due to the ANSI log settings.")
+            } else if(config.monochromeLogs instanceof Boolean) {
                 monochromeLogs = config.monochromeLogs
                 log.debug("Set `validation.monochromeLogs` to ${monochromeLogs}")
             } else {

--- a/src/main/groovy/nextflow/validation/help/HelpObserver.groovy
+++ b/src/main/groovy/nextflow/validation/help/HelpObserver.groovy
@@ -17,7 +17,7 @@ class HelpObserver implements TraceObserverV2 {
     void onFlowCreate(Session session) {
         // Help message logic
         def Map params = (Map)session.params ?: [:]
-        def ValidationConfig config = new ValidationConfig(session?.config?.navigate('validation') as Map, params)
+        def ValidationConfig config = new ValidationConfig(session?.config?.navigate('validation') as Map, session)
         def Boolean containsFullParameter = params.containsKey(config.help.fullParameter) && params[config.help.fullParameter]
         def Boolean containsShortParameter = params.containsKey(config.help.shortParameter) && params[config.help.shortParameter]
         if (config.help.enabled && (containsFullParameter || containsShortParameter)) {

--- a/src/test/groovy/nextflow/validation/ConfigTest.groovy
+++ b/src/test/groovy/nextflow/validation/ConfigTest.groovy
@@ -67,7 +67,7 @@ class ConfigTest extends Dsl2Spec{
         def params = [:]
 
         when:
-        new ValidationConfig(config, params)
+        new ValidationConfig(config, session)
         def stdout = capture
             .toString()
             .readLines()
@@ -108,7 +108,7 @@ class ConfigTest extends Dsl2Spec{
         def params = [:]
 
         when:
-        new ValidationConfig(config, params)
+        new ValidationConfig(config, session)
         def stdout = capture
             .toString()
             .readLines()
@@ -149,7 +149,7 @@ class ConfigTest extends Dsl2Spec{
         def params = [:]
 
         when:
-        new ValidationConfig(config, params)
+        new ValidationConfig(config, session)
         def stdout = capture
             .toString()
             .readLines()

--- a/src/test/groovy/nextflow/validation/HelpMessageCreatorTest.groovy
+++ b/src/test/groovy/nextflow/validation/HelpMessageCreatorTest.groovy
@@ -49,7 +49,7 @@ class HelpMessageCreatorTest extends Specification{
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:
@@ -94,7 +94,7 @@ Reference genome options
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:
@@ -172,8 +172,12 @@ copyNoFollow, move) [default: copy]
         def params = [
             showMeThoseHiddenParams:true
         ]
-        def config = new ValidationConfig(validationConfig, params)
-        def helpCreator = new HelpMessageCreator(config, session)
+        // Create new session to use the parameter
+        def newSession = Mock(Session)
+        newSession.getBaseDir() >> getRoot()
+        newSession.params >> params
+        def config = new ValidationConfig(validationConfig, newSession)
+        def helpCreator = new HelpMessageCreator(config, newSession)
 
         when:
         def help = helpCreator.getShortMessage("")
@@ -247,7 +251,7 @@ copyNoFollow, move) [default: copy]
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:
@@ -283,7 +287,7 @@ Nested Parameters
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:
@@ -315,7 +319,7 @@ Nested Parameters
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:
@@ -357,7 +361,7 @@ Etiam at nulla ac dui ullamcorper viverra. Donec posuere imperdiet eros nec cons
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:
@@ -393,7 +397,7 @@ Etiam at nulla ac dui ullamcorper viverra. Donec posuere imperdiet eros nec cons
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:
@@ -426,7 +430,7 @@ Etiam at nulla ac dui ullamcorper viverra. Donec posuere imperdiet eros nec cons
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:
@@ -457,7 +461,7 @@ Etiam at nulla ac dui ullamcorper viverra. Donec posuere imperdiet eros nec cons
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:
@@ -504,7 +508,7 @@ Reference genome options
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:
@@ -542,7 +546,7 @@ or `--helpFull`.
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:
@@ -566,7 +570,7 @@ or `--helpFull`.
             ]
         ]
         def params = [:]
-        def config = new ValidationConfig(validationConfig, params)
+        def config = new ValidationConfig(validationConfig, session)
         def helpCreator = new HelpMessageCreator(config, session)
 
         when:

--- a/src/test/groovy/nextflow/validation/ParamsSummaryLogTest.groovy
+++ b/src/test/groovy/nextflow/validation/ParamsSummaryLogTest.groovy
@@ -70,7 +70,7 @@ class ParamsSummaryLogTest extends Dsl2Spec{
     def 'should print params summary' () {
         given:
         def schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath().toString()
-        def  SCRIPT_TEXT = """
+        def  SCRIPT = """
             params.outdir = "outDir"
             include { paramsSummaryLog } from 'plugin/nf-schema'
             
@@ -79,7 +79,8 @@ class ParamsSummaryLogTest extends Dsl2Spec{
         """
 
         when:
-        dsl_eval(SCRIPT_TEXT)
+        def config = [:]
+        def result = new MockScriptRunner(config).setScript(SCRIPT).execute()
         def stdout = capture
                 .toString()
                 .readLines()
@@ -99,7 +100,7 @@ class ParamsSummaryLogTest extends Dsl2Spec{
         then:
         noExceptionThrown()
         stdout.size() == 11
-        stdout ==~ /.*\[0;34moutdir     : .\[0;32moutDir.*/
+        stdout ==~ /.*outdir     : outDir.*/
     }
 
     def 'should print params summary - nested parameters' () {
@@ -145,7 +146,7 @@ class ParamsSummaryLogTest extends Dsl2Spec{
         then:
         noExceptionThrown()
         stdout.size() == 11
-        stdout ==~ /.*\[0;34mthis.is.so.deep: .\[0;32mchanged_value.*/
+        stdout ==~ /.*this.is.so.deep: changed_value.*/
     }
 
     def 'should print params summary - adds before and after text' () {
@@ -191,7 +192,7 @@ class ParamsSummaryLogTest extends Dsl2Spec{
         then:
         noExceptionThrown()
         stdout.size() == 14
-        stdout ==~ /.*\[0;34moutdir     : .\[0;32moutDir.*/
+        stdout ==~ /.*outdir     : outDir.*/
     }
 
     def 'should print params summary - nested parameters - hide params' () {
@@ -242,7 +243,7 @@ class ParamsSummaryLogTest extends Dsl2Spec{
         then:
         noExceptionThrown()
         stdout.size() == 10
-        stdout !=~ /.*\[0;34mthis.is.so.deep: .\[0;32mchanged_value.*/
+        stdout !=~ /.*this.is.so.deep: changed_value.*/
     }
 
     def 'should print params summary - hide params' () {
@@ -283,6 +284,6 @@ class ParamsSummaryLogTest extends Dsl2Spec{
         then:
         noExceptionThrown()
         stdout.size() == 9
-        stdout !=~ /.*\[0;34moutdir     : .\[0;32moutDir.*/
+        stdout !=~ /.*outdir     : outDir.*/
     }
 }

--- a/src/test/groovy/nextflow/validation/ValidateParametersTest.groovy
+++ b/src/test/groovy/nextflow/validation/ValidateParametersTest.groovy
@@ -246,7 +246,7 @@ class ValidateParametersTest extends Dsl2Spec{
         then:
         def error = thrown(SchemaValidationException)
         def errorMessages = error.message.readLines()
-        errorMessages[0] == "\033[0;31mThe following invalid input values have been detected:"
+        errorMessages[0] == "The following invalid input values have been detected:"
         errorMessages[1] == ""
         errorMessages[2] == "* --input (src/testResources/wrong.csv): Validation of file failed:"
         errorMessages[3] == "\t-> Entry 1: Error for field 'strandedness' (weird): Expected any of [[forward, reverse, unstranded]] (Strandedness must be provided and be one of 'forward', 'reverse' or 'unstranded')"
@@ -280,7 +280,7 @@ class ValidateParametersTest extends Dsl2Spec{
         then:
         def error = thrown(SchemaValidationException)
         def errorMessages = error.message.readLines()
-        errorMessages[0] == "\033[0;31mThe following invalid input values have been detected:"
+        errorMessages[0] == "The following invalid input values have been detected:"
         errorMessages[1] == ""
         errorMessages[2] == "* --input (src/testResources/wrong.tsv): Validation of file failed:"
         errorMessages[3] == "\t-> Entry 1: Error for field 'strandedness' (weird): Expected any of [[forward, reverse, unstranded]] (Strandedness must be provided and be one of 'forward', 'reverse' or 'unstranded')"
@@ -314,7 +314,7 @@ class ValidateParametersTest extends Dsl2Spec{
         then:
         def error = thrown(SchemaValidationException)
         def errorMessages = error.message.readLines()
-        errorMessages[0] == "\033[0;31mThe following invalid input values have been detected:"
+        errorMessages[0] == "The following invalid input values have been detected:"
         errorMessages[1] == ""
         errorMessages[2] == "* --input (src/testResources/wrong.yaml): Validation of file failed:"
         errorMessages[3] == "\t-> Entry 1: Error for field 'strandedness' (weird): Expected any of [[forward, reverse, unstranded]] (Strandedness must be provided and be one of 'forward', 'reverse' or 'unstranded')"
@@ -348,7 +348,7 @@ class ValidateParametersTest extends Dsl2Spec{
         then:
         def error = thrown(SchemaValidationException)
         def errorMessages = error.message.readLines()
-        errorMessages[0] == "\033[0;31mThe following invalid input values have been detected:"
+        errorMessages[0] == "The following invalid input values have been detected:"
         errorMessages[1] == ""
         errorMessages[2] == "* --input (src/testResources/wrong.json): Validation of file failed:"
         errorMessages[3] == "\t-> Entry 1: Error for field 'strandedness' (weird): Expected any of [[forward, reverse, unstranded]] (Strandedness must be provided and be one of 'forward', 'reverse' or 'unstranded')"


### PR DESCRIPTION
Fixes #12 

This PR sets the monochromeLogs option to what the ansi log settings are in Nextflow. This will take priority over the current monochromeLogs config option.