### PR TITLE
Prevent invalid parameters to be printed out on validation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Bug fixes
 
 1. CSV and TSV files with trailing commas or tabs will now be properly sanitized. This fixes issues with CSV and TSV files that contained empty header columns.
+2. Unidentified parameters are no longer printed out on failure of the parameter validation. This is to prevent a bug where all parameters would be printed out on failure.
 
 # Version 2.4.2
 

--- a/src/main/groovy/nextflow/validation/validators/JsonSchemaValidator.groovy
+++ b/src/main/groovy/nextflow/validation/validators/JsonSchemaValidator.groovy
@@ -116,7 +116,10 @@ public class JsonSchemaValidator {
             errors.add(printableError)
 
         }
-        def List<String> unevaluated = getUnevaluated(result, rawJson)
+        def List<String> unevaluated = []
+        if(errors.size() == 0) { 
+            unevaluated = getUnevaluated(result, rawJson)
+        }
         return Tuple.tuple(errors, unevaluated)
     }
 


### PR DESCRIPTION
Fixes #144 

This PR prevents detection of unevaluated parameters on validation failure. The `.getAnnotation()` method returns an empty list on failure, causing all parameters to be considered invalid instead of only the unrecognised ones.

@awgymer could you take a look at this since this touches code your wrote?