### PR TITLE
Fix default value `null` not being set correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 1. CSV and TSV files with trailing commas or tabs will now be properly sanitized. This fixes issues with CSV and TSV files that contained empty header columns.
 2. Unidentified parameters are no longer printed out on failure of the parameter validation. This is to prevent a bug where all parameters would be printed out on failure.
+3. Fixed an issue where default values of `null` weren't being set correctly in `samplesheetToList()`.
 
 # Version 2.4.2
 

--- a/src/main/groovy/nextflow/validation/samplesheet/SamplesheetConverter.groovy
+++ b/src/main/groovy/nextflow/validation/samplesheet/SamplesheetConverter.groovy
@@ -140,7 +140,7 @@ class SamplesheetConverter {
     private Object formatEntry(Object input, Map schema, String headerPrefix = "") {
 
         // Add default values for missing entries
-        input = input != null ? input : findDeep(schema, "default") != null ? findDeep(schema, "default") : []
+        input = input != null ? input : hasDeepKey(schema, "default") ? findDeep(schema, "default") : []
 
         if (input instanceof Map) {
             def List result = []

--- a/src/main/groovy/nextflow/validation/samplesheet/SamplesheetConverter.groovy
+++ b/src/main/groovy/nextflow/validation/samplesheet/SamplesheetConverter.groovy
@@ -12,6 +12,7 @@ import static nextflow.validation.utils.Colors.getLogColors
 import static nextflow.validation.utils.Files.fileToJson
 import static nextflow.validation.utils.Files.fileToObject
 import static nextflow.validation.utils.Common.findDeep
+import static nextflow.validation.utils.Common.hasDeepKey
 import nextflow.validation.config.ValidationConfig
 import nextflow.validation.exceptions.SchemaValidationException
 import nextflow.validation.validators.JsonSchemaValidator
@@ -248,7 +249,7 @@ class SamplesheetConverter {
     */
     private Object processMeta(Object input, Map schema, String headerPrefix) {
         // Add default values for missing entries
-        input = input != null ? input : findDeep(schema, "default") != null ? findDeep(schema, "default") : []
+        input = input != null ? input : hasDeepKey(schema, "default") ? findDeep(schema, "default") : []
 
         if (input instanceof Map) {
             def Map result = [:]

--- a/src/main/groovy/nextflow/validation/utils/Common.groovy
+++ b/src/main/groovy/nextflow/validation/utils/Common.groovy
@@ -76,6 +76,23 @@ public class Common {
         return null
     }
 
+    //
+    // Check if a key exists in a nested map
+    //
+    public static boolean hasDeepKey(Object m, String key) {
+        if (m instanceof Map) {
+            if (m.containsKey(key)) {
+                return true
+            } else {
+                return m.any { k, v -> hasDeepKey(v, key) }
+            }
+        } 
+        else if (m instanceof List) {
+            return m.any { element -> hasDeepKey(element, key) }
+        }
+        return false
+    }
+
     public static void findAllKeys(Object object, String key, Set<String> finalKeys, String sep) {
         if (object instanceof JSONObject) {
             JSONObject jsonObject = (JSONObject) object;

--- a/src/test/groovy/nextflow/validation/SamplesheetConverterTest.groovy
+++ b/src/test/groovy/nextflow/validation/SamplesheetConverterTest.groovy
@@ -689,4 +689,29 @@ class SamplesheetConverterTest extends Dsl2Spec{
         stdout.contains("[file1.txt, file2.txt]")
 
     }
+
+    def 'samplesheetToList - correctly set defaults' () {
+        given:
+        def SCRIPT_TEXT = '''
+            include { samplesheetToList } from 'plugin/nf-schema'
+
+            workflow {
+                Channel.fromList(samplesheetToList("src/testResources/samplesheet_defaults.yaml", "src/testResources/schema_input_defaults.json")).view()       
+            }
+
+        '''
+
+        when:
+        dsl_eval(SCRIPT_TEXT)
+        def stdout = capture
+                .toString()
+                .readLines()
+                .findResults {it.startsWith('[') ? it : null }
+
+        then:
+        noExceptionThrown()
+        stdout.contains("[[nullValue:null], 25, defaultString, true, test]")
+        stdout.contains("[[nullValue:null], 0, defaultString, true, null]")
+    }
+    
 }

--- a/src/testResources/samplesheet_defaults.yaml
+++ b/src/testResources/samplesheet_defaults.yaml
@@ -1,0 +1,2 @@
+- null_default: test
+- integer: 0

--- a/src/testResources/schema_input_defaults.json
+++ b/src/testResources/schema_input_defaults.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/nextflow-io/nf-schema/master/src/testResources/schema_input.json",
+    "title": "Samplesheet validation schema",
+    "description": "Schema for the samplesheet used in this pipeline",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "integer": {
+                "type": "integer",
+                "default": 25
+            },
+            "string": {
+                "type": "string",
+                "default": "defaultString"
+            },
+            "boolean": {
+                "type": "boolean",
+                "default": true
+            },
+            "null_default": {
+                "type": "string",
+                "default": null
+            },
+            "null_meta": {
+                "type": "string",
+                "meta": "nullValue",
+                "default": null
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #163 

This PR adds a new method `hasDeepKey` which checks if a certain key is set before fetching the value with `findDeep`. This will prevent us doing checks on the default value in this case and replace it with an exist check for the `default` key