### PR TITLE
Mask fusion mount and s3 bucket names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # nextflow-io/nf-schema: Changelog
 
+# Version 2.7.3
+
+## New features
+
+1. Added new configuration options to mask paths when generating the summary message:
+  - `mask`: Mask value, when replacing bucket names or subpaths (optional, default: `[** masked **]`).
+  - `maskSubpaths`: A list of subpaths to mask from path values (optional, default: `[]`).
+
 # Version 2.7.2
 
 ## New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ## New features
 
 1. Added new configuration options to mask paths when generating the summary message:
-  - `mask`: Mask value, when replacing bucket names or subpaths (optional, default: `[** masked **]`).
-  - `maskSubpaths`: A list of subpaths to mask from path values (optional, default: `[]`).
+   - `mask`: Mask value, when replacing bucket names or subpaths (optional, default: `[** masked **]`).
+   - `maskSubpaths`: A list of subpaths to mask from path values (optional, default: `[]`).
 
 # Version 2.7.2
 

--- a/docs/parameters/summary_log.md
+++ b/docs/parameters/summary_log.md
@@ -20,12 +20,14 @@ The function takes one required argument:
 
 - The `WorkflowMetadata` object, `workflow` (required)
 
-And four optional arguments:
+And optional arguments:
 
 - `parameters_schema`: File name of a schema file (optional, default: `nextflow_schema.json`).
 - `monochrome_logs`: Boolean to disable coloured logs (optional, default: `false`).
 - `beforeText`: String to add before the summary log (optional, default: `''`).
 - `afterText`: String to add after the summary log (optional, default: `''`).
+- `mask`: Mask value, when replacing bucket names or subpaths (optional, default: `[** masked **]`).
+- `maskSubpaths`: A list of subpaths to mask from path values (optional, default: `[]`).
 
 Typical usage:
 

--- a/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
@@ -31,6 +31,14 @@ class SummaryConfig implements ConfigScope {
     @Description('A list of parameters to hide in the summary message.')
     final Set<CharSequence> hideParams = []
 
+    @ConfigOption
+    @Description('Mask /fusion from path values.')
+    final public boolean maskFusionMount
+
+    @ConfigOption
+    @Description('Mask /s3/bucket/ and s3://bucket/ from path values.')
+    final public boolean maskBucketNames
+
     SummaryConfig(Map map, Boolean monochromeLogs) {
         Map config = map ?: Collections.emptyMap()
 
@@ -74,6 +82,17 @@ class SummaryConfig implements ConfigScope {
                 log.warn("Incorrect value detected for `validation.summary.hideParams`, a list of strings is expected. Defaulting to `${hideParams}`")
             }
         }
-    }
 
+        // maskFusionMount
+        if(config.containsKey("maskFusionMount")) {
+            maskFusionMount = config.maskFusionMount
+            log.debug("Set `maskFusionMount` to ${maskFusionMount}")
+        }
+
+        // maskBucketNames
+        if(config.containsKey("maskBucketNames")) {
+            maskBucketNames = config.maskBucketNames
+            log.debug("Set `maskBucketNames` to ${maskBucketNames}")
+        }
+    }
 }

--- a/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
@@ -95,13 +95,15 @@ class SummaryConfig implements ConfigScope {
         }
 
         // maskSubpaths
-        if(config.containsKey('maskSubpaths')) {
-            if(config.maskSubpaths instanceof List<CharSequence>) {
+        if (config.containsKey('maskSubpaths')) {
+            if (config.maskSubpaths in List<CharSequence>) {
                 maskSubpaths = config.maskSubpaths
                 log.debug("Set `maskSubpaths` to ${maskSubpaths}")
             } else {
-                log.warn('Incorrect value detected for `validation.summary.maskSubpaths`, a list of strings is expected. Defaulting to ``')
+                log.warn('Incorrect value detected for `validation.summary.maskSubpaths`, a list of strings'
+                         + ' is expected. Defaulting to ``')
             }
         }
     }
+
 }

--- a/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
@@ -39,6 +39,10 @@ class SummaryConfig implements ConfigScope {
     @Description('Mask /s3/bucket/ and s3://bucket/ from path values.')
     final public boolean maskBucketNames
 
+    @ConfigOption
+    @Description('A list of subpaths to mask from path values.')
+    final public List<CharSequence> maskFromPaths
+
     SummaryConfig(Map map, Boolean monochromeLogs) {
         Map config = map ?: Collections.emptyMap()
 
@@ -84,15 +88,33 @@ class SummaryConfig implements ConfigScope {
         }
 
         // maskFusionMount
-        if(config.containsKey("maskFusionMount")) {
-            maskFusionMount = config.maskFusionMount
-            log.debug("Set `maskFusionMount` to ${maskFusionMount}")
+        if(config.containsKey('maskFusionMount')) {
+            if(config.maskFusionMount instanceof Boolean) {
+                maskFusionMount = config.maskFusionMount
+                log.debug("Set `maskFusionMount` to ${maskFusionMount}")
+            } else {
+                log.warn('Incorrect value detected for `validation.summary.maskFusionMount`, a boolean is expected. Defaulting to `false`')
+            }
         }
 
         // maskBucketNames
-        if(config.containsKey("maskBucketNames")) {
-            maskBucketNames = config.maskBucketNames
-            log.debug("Set `maskBucketNames` to ${maskBucketNames}")
+        if(config.containsKey('maskBucketNames')) {
+            if(config.maskBucketNames instanceof Boolean) {
+                maskBucketNames = config.maskBucketNames
+                log.debug("Set `maskBucketNames` to ${maskBucketNames}")
+            } else {
+                log.warn('Incorrect value detected for `validation.summary.maskBucketNames`, a boolean is expected. Defaulting to `false`')
+            }
+        }
+
+        // maskFromPaths
+        if(config.containsKey('maskFromPaths')) {
+            if(config.maskFromPaths instanceof List<CharSequence>) {
+                maskFromPaths = config.maskFromPaths
+                log.debug("Set `maskFromPaths` to ${maskFromPaths}")
+            } else {
+                log.warn('Incorrect value detected for `validation.summary.maskFromPaths`, a list of strings is expected. Defaulting to ``')
+            }
         }
     }
 }

--- a/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
@@ -100,8 +100,8 @@ class SummaryConfig implements ConfigScope {
                 maskSubpaths = config.maskSubpaths
                 log.debug("Set `maskSubpaths` to ${maskSubpaths}")
             } else {
-                log.warn('Incorrect value detected for `validation.summary.maskSubpaths`, a list of strings'
-                         + ' is expected. Defaulting to ``')
+                /* groovylint-disable-next-line LineLength */
+                log.warn('Incorrect value detected for `validation.summary.maskSubpaths`, a list of strings is expected. Defaulting to ``')
             }
         }
     }

--- a/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
@@ -33,11 +33,11 @@ class SummaryConfig implements ConfigScope {
 
     @ConfigOption
     @Description('Mask value, when replacing bucket names or subpaths. Defaults to [** masked **].')
-    final public CharSequence mask
+    CharSequence mask = '[** masked **]'
 
     @ConfigOption
     @Description('A list of subpaths to mask from path values.')
-    final public List<CharSequence> maskSubpaths
+    final List<CharSequence> maskSubpaths
 
     SummaryConfig(Map map, Boolean monochromeLogs) {
         Map config = map ?: Collections.emptyMap()
@@ -89,12 +89,9 @@ class SummaryConfig implements ConfigScope {
                 mask = config.mask
                 log.debug("Set `validation.summary.mask` to ${mask}")
             } else {
-                mask = '[** masked **]'
                 /* groovylint-disable-next-line LineLength */
                 log.warn("Incorrect value detected for `validation.summary.mask`, a string is expected. Defaulting to `${mask}`")
             }
-        } else {
-            mask = '[** masked **]'
         }
 
         // maskSubpaths

--- a/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
+++ b/src/main/groovy/nextflow/validation/config/SummaryConfig.groovy
@@ -32,16 +32,12 @@ class SummaryConfig implements ConfigScope {
     final Set<CharSequence> hideParams = []
 
     @ConfigOption
-    @Description('Mask /fusion from path values.')
-    final public boolean maskFusionMount
-
-    @ConfigOption
-    @Description('Mask /s3/bucket/ and s3://bucket/ from path values.')
-    final public boolean maskBucketNames
+    @Description('Mask value, when replacing bucket names or subpaths. Defaults to [** masked **].')
+    final public CharSequence mask
 
     @ConfigOption
     @Description('A list of subpaths to mask from path values.')
-    final public List<CharSequence> maskFromPaths
+    final public List<CharSequence> maskSubpaths
 
     SummaryConfig(Map map, Boolean monochromeLogs) {
         Map config = map ?: Collections.emptyMap()
@@ -87,33 +83,27 @@ class SummaryConfig implements ConfigScope {
             }
         }
 
-        // maskFusionMount
-        if(config.containsKey('maskFusionMount')) {
-            if(config.maskFusionMount instanceof Boolean) {
-                maskFusionMount = config.maskFusionMount
-                log.debug("Set `maskFusionMount` to ${maskFusionMount}")
+        // mask
+        if (config.containsKey('mask')) {
+            if (config.mask in CharSequence) {
+                mask = config.mask
+                log.debug("Set `validation.summary.mask` to ${mask}")
             } else {
-                log.warn('Incorrect value detected for `validation.summary.maskFusionMount`, a boolean is expected. Defaulting to `false`')
+                mask = '[** masked **]'
+                /* groovylint-disable-next-line LineLength */
+                log.warn("Incorrect value detected for `validation.summary.mask`, a string is expected. Defaulting to `${mask}`")
             }
+        } else {
+            mask = '[** masked **]'
         }
 
-        // maskBucketNames
-        if(config.containsKey('maskBucketNames')) {
-            if(config.maskBucketNames instanceof Boolean) {
-                maskBucketNames = config.maskBucketNames
-                log.debug("Set `maskBucketNames` to ${maskBucketNames}")
+        // maskSubpaths
+        if(config.containsKey('maskSubpaths')) {
+            if(config.maskSubpaths instanceof List<CharSequence>) {
+                maskSubpaths = config.maskSubpaths
+                log.debug("Set `maskSubpaths` to ${maskSubpaths}")
             } else {
-                log.warn('Incorrect value detected for `validation.summary.maskBucketNames`, a boolean is expected. Defaulting to `false`')
-            }
-        }
-
-        // maskFromPaths
-        if(config.containsKey('maskFromPaths')) {
-            if(config.maskFromPaths instanceof List<CharSequence>) {
-                maskFromPaths = config.maskFromPaths
-                log.debug("Set `maskFromPaths` to ${maskFromPaths}")
-            } else {
-                log.warn('Incorrect value detected for `validation.summary.maskFromPaths`, a list of strings is expected. Defaulting to ``')
+                log.warn('Incorrect value detected for `validation.summary.maskSubpaths`, a list of strings is expected. Defaulting to ``')
             }
         }
     }

--- a/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
+++ b/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
@@ -50,12 +50,12 @@ class SummaryCreator {
             workflowSummary['container'] = workflow.container
         }
 
-        workflowSummary['launchDir']    = workflow.launchDir
-        workflowSummary['workDir']      = workflow.workDir
-        workflowSummary['projectDir']   = workflow.projectDir
+        workflowSummary['launchDir']    = maybeMask(workflow.launchDir)
+        workflowSummary['workDir']      = maybeMask(workflow.workDir)
+        workflowSummary['projectDir']   = maybeMask(workflow.projectDir)
         workflowSummary['userName']     = workflow.userName
         workflowSummary['profile']      = workflow.profile
-        workflowSummary['configFiles']  = workflow.configFiles ? workflow.configFiles.join(', ') : ''
+        workflowSummary['configFiles']  = maybeMask(workflow.configFiles ? workflow.configFiles.join(', ') : '')
 
         // Get pipeline parameters defined in JSON Schema
         Map paramsSummary = [:]
@@ -121,18 +121,26 @@ class SummaryCreator {
 
                 // We have a default in the schema, and this isn't it
                 if (defaultValue != null && value != defaultValue) {
-                    summary.put(param, maybeMaskFusionMount(maybeMaskBucketNames((value))))
+                    summary.put(param, maybeMask(value))
                 }
                 // No default in the schema, and this isn't empty or false
                 else if (defaultValue == null && value != '' && value != null && value != false && value != 'false') {
-                    summary.put(param, maybeMaskFusionMount(maybeMaskBucketNames((value))))
+                    summary.put(param, maybeMask(value))
                 }
             }
         }
         return summary
     }
 
-    private String maybeMaskFusionMount(String value) {
+    private CharSequence maybeMask(Path value) {
+        return maybeMask(value.toString())
+    }
+
+    private CharSequence maybeMask(CharSequence value) {
+        return maybeMaskFusionMount(maybeMaskBucketNames(maybeMaskFromPaths(value)))
+    }
+
+    private CharSequence maybeMaskFusionMount(CharSequence value) {
         if(config.summary.maskFusionMount) {
             return value.replace('/fusion', '')
         }
@@ -140,13 +148,22 @@ class SummaryCreator {
     }
 
     // see https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-    static final String S3_BUCKET_PATH_PREFIX = '\\/s3\\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\\/'
-    static final String S3_BUCKET_URI_PREFIX = 's3:\\/\\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\\/'
+    static final CharSequence S3_BUCKET_PATH_PREFIX = '\\/s3\\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\\/'
+    static final CharSequence S3_BUCKET_URI_PREFIX = 's3:\\/\\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\\/'
 
-    private String maybeMaskBucketNames(String value) {
-        if (config.summary.maskBucketNames) {
-            value.replaceAll(S3_BUCKET_PATH_PREFIX, '')
-            value.replaceAll(S3_BUCKET_URI_PREFIX, '')
+    private CharSequence maybeMaskBucketNames(CharSequence value) {
+        if(config.summary.maskBucketNames) {
+            value = value.replaceAll(S3_BUCKET_PATH_PREFIX, '/[** masked **]/')
+            value = value.replaceAll(S3_BUCKET_URI_PREFIX, '[** masked **]/')
+        }
+        return value
+    }
+
+    private CharSequence maybeMaskFromPaths(CharSequence value) {
+        if(config.summary.maskFromPaths != null && config.summary.maskFromPaths.size() > 0) {
+            for (CharSequence toReplace : config.summary.maskFromPaths) {
+                value = value.replace(toReplace, '[** masked **]')
+            }
         }
         return value
     }

--- a/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
+++ b/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
@@ -133,36 +133,17 @@ class SummaryCreator {
     }
 
     private CharSequence maybeMask(Path value) {
-        return maybeMask(value.toString())
+        return maybeMask(value.toUriString())
     }
 
     private CharSequence maybeMask(CharSequence value) {
-        return maybeMaskFusionMount(maybeMaskBucketNames(maybeMaskFromPaths(value)))
+        return maybeMaskSubpaths(value)
     }
 
-    private CharSequence maybeMaskFusionMount(CharSequence value) {
-        if(config.summary.maskFusionMount) {
-            return value.replace('/fusion', '')
-        }
-        return value
-    }
-
-    // see https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-    static final CharSequence S3_BUCKET_PATH_PREFIX = '\\/s3\\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\\/'
-    static final CharSequence S3_BUCKET_URI_PREFIX = 's3:\\/\\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\\/'
-
-    private CharSequence maybeMaskBucketNames(CharSequence value) {
-        if(config.summary.maskBucketNames) {
-            value = value.replaceAll(S3_BUCKET_PATH_PREFIX, '/[** masked **]/')
-            value = value.replaceAll(S3_BUCKET_URI_PREFIX, '[** masked **]/')
-        }
-        return value
-    }
-
-    private CharSequence maybeMaskFromPaths(CharSequence value) {
-        if(config.summary.maskFromPaths != null && config.summary.maskFromPaths.size() > 0) {
-            for (CharSequence toReplace : config.summary.maskFromPaths) {
-                value = value.replace(toReplace, '[** masked **]')
+    private CharSequence maybeMaskSubpaths(CharSequence value) {
+        if(config.summary.maskSubpaths != null && config.summary.maskSubpaths.size() > 0) {
+            for (CharSequence toReplace : config.summary.maskSubpaths) {
+                value = value.replaceAll(toReplace, config.summary.mask)
             }
         }
         return value

--- a/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
+++ b/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
@@ -141,11 +141,13 @@ class SummaryCreator {
     }
 
     private CharSequence maybeMaskSubpaths(CharSequence value) {
-        if(config.summary.maskSubpaths?.size() > 0) {
+        CharSequence v = value
+        if (config.summary.maskSubpaths?.size() > 0) {
             config.summary.maskSubpaths.each { CharSequence toReplace ->
-                value = value.replaceAll(toReplace, config.summary.mask)
+                v = v.replaceAll(toReplace, config.summary.mask)
             }
         }
-        return value
+        return v
     }
+
 }

--- a/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
+++ b/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
@@ -141,7 +141,7 @@ class SummaryCreator {
     }
 
     private CharSequence maybeMaskSubpaths(CharSequence value) {
-        if(config.summary.maskSubpaths != null && config.summary.maskSubpaths.size() > 0) {
+        if(config.summary.maskSubpaths?.size() > 0) {
             for (CharSequence toReplace : config.summary.maskSubpaths) {
                 value = value.replaceAll(toReplace, config.summary.mask)
             }

--- a/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
+++ b/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
@@ -142,7 +142,7 @@ class SummaryCreator {
 
     private CharSequence maybeMaskSubpaths(CharSequence value) {
         if(config.summary.maskSubpaths?.size() > 0) {
-            for (CharSequence toReplace : config.summary.maskSubpaths) {
+            config.summary.maskSubpaths.each { CharSequence toReplace ->
                 value = value.replaceAll(toReplace, config.summary.mask)
             }
         }

--- a/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
+++ b/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
@@ -121,15 +121,33 @@ class SummaryCreator {
 
                 // We have a default in the schema, and this isn't it
                 if (defaultValue != null && value != defaultValue) {
-                    summary.put(param, value)
+                    summary.put(param, maybeMaskFusionMount(maybeMaskBucketNames((value))))
                 }
                 // No default in the schema, and this isn't empty or false
                 else if (defaultValue == null && value != '' && value != null && value != false && value != 'false') {
-                    summary.put(param, value)
+                    summary.put(param, maybeMaskFusionMount(maybeMaskBucketNames((value))))
                 }
             }
         }
         return summary
     }
 
+    private String maybeMaskFusionMount(String value) {
+        if(config.summary.maskFusionMount) {
+            return value.replace("/fusion", "")
+        }
+        return value
+    }
+
+    // see https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+    static final String S3_BUCKET_PATH_PREFIX = '\\/s3\\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\\/'
+    static final String S3_BUCKET_URI_PREFIX = 's3:\\/\\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\\/'
+
+    private String maybeMaskBucketNames(String value) {
+        if (config.summary.maskBucketNames) {
+            value.replaceAll(S3_BUCKET_PATH_PREFIX, '')
+            value.replaceAll(S3_BUCKET_URI_PREFIX, '')
+        }
+        return value
+    }
 }

--- a/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
+++ b/src/main/groovy/nextflow/validation/summary/SummaryCreator.groovy
@@ -134,7 +134,7 @@ class SummaryCreator {
 
     private String maybeMaskFusionMount(String value) {
         if(config.summary.maskFusionMount) {
-            return value.replace("/fusion", "")
+            return value.replace('/fusion', '')
         }
         return value
     }

--- a/src/test/groovy/nextflow/validation/ConfigTest.groovy
+++ b/src/test/groovy/nextflow/validation/ConfigTest.groovy
@@ -44,8 +44,7 @@ class ConfigTest extends Dsl2Spec {
                 beforeText: 'before',
                 afterText: 'after',
                 hideParams: ['some_random_param'],
-                maskFusionMount: false,
-                maskBucketNames: false
+                mask: 'mask'
             ],
             logging: [
                 unrecognisedParams: 'error',
@@ -89,8 +88,7 @@ class ConfigTest extends Dsl2Spec {
                 beforeText: "${randomString}",
                 afterText: "${randomString}",
                 hideParams: ["${randomString}"],
-                maskFusionMount: false,
-                maskBucketNames: false
+                mask: "${randomString}"
             ],
             logging: [
                 unrecognisedParams: "${errorLevel}",

--- a/src/test/groovy/nextflow/validation/ConfigTest.groovy
+++ b/src/test/groovy/nextflow/validation/ConfigTest.groovy
@@ -44,6 +44,8 @@ class ConfigTest extends Dsl2Spec {
                 beforeText: 'before',
                 afterText: 'after',
                 hideParams: ['some_random_param'],
+                maskFusionMount: false,
+                maskBucketNames: false
             ],
             logging: [
                 unrecognisedParams: 'error',
@@ -87,6 +89,8 @@ class ConfigTest extends Dsl2Spec {
                 beforeText: "${randomString}",
                 afterText: "${randomString}",
                 hideParams: ["${randomString}"],
+                maskFusionMount: false,
+                maskBucketNames: false
             ],
             logging: [
                 unrecognisedParams: "${errorLevel}",

--- a/src/test/groovy/nextflow/validation/ParamsSummaryLogTest.groovy
+++ b/src/test/groovy/nextflow/validation/ParamsSummaryLogTest.groovy
@@ -347,4 +347,93 @@ class ParamsSummaryLogTest extends Dsl2Spec {
         stdout != ~ /.*outdir     : outDir.*/
     }
 
+    void 'should print params summary - mask params - default mask'() {
+        given:
+        String schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath()
+        String script = """
+            params.outdir = "s3://bucket/outDir"
+            include { paramsSummaryLog } from 'plugin/nf-schema'
+
+            def summary_params = paramsSummaryLog(workflow, parameters_schema: '$schema')
+            log.info summary_params
+        """
+
+        when:
+        Map config = [
+            'validation': [
+                'summary': [
+                    'hideParams': ['outdir'],
+                    'maskSubpaths': 's3:\\/\\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\\/'
+                ]
+            ]
+        ]
+        new MockScriptRunner(config).setScript(script).execute()
+        List<String> stdout = capture
+                .toString()
+                .readLines()
+                .findResults { line ->
+                    line.contains('Only displaying parameters that differ from the pipeline defaults') ||
+                    line.contains('Core Nextflow options') ||
+                    line.contains('runName') ||
+                    line.contains('launchDir') ||
+                    line.contains('workDir') ||
+                    line.contains('projectDir') ||
+                    line.contains('userName') ||
+                    line.contains('profile') ||
+                    line.contains('configFiles') ||
+                    line.contains('outdir ')
+                    ? line : null
+                }
+
+        then:
+        noExceptionThrown()
+        stdout.size() == 9
+        stdout != ~ /.*outdir     : [** masked **]\\/outDir.*/
+    }
+
+    void 'should print params summary - mask params - custom mask'() {
+        given:
+        String schema = Path.of('src/testResources/nextflow_schema.json').toAbsolutePath()
+        String script = """
+            params.outdir = "s3://bucket/outDir"
+            include { paramsSummaryLog } from 'plugin/nf-schema'
+
+            def summary_params = paramsSummaryLog(workflow, parameters_schema: '$schema')
+            log.info summary_params
+        """
+
+        when:
+        Map config = [
+            'validation': [
+                'summary': [
+                    'hideParams': ['outdir'],
+                    'mask': '/mask',
+                    'maskSubpaths': 's3:\\/\\/[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\\/'
+                ]
+            ]
+        ]
+        new MockScriptRunner(config).setScript(script).execute()
+        List<String> stdout = capture
+                .toString()
+                .readLines()
+                .findResults { line ->
+                    line.contains('Only displaying parameters that differ from the pipeline defaults') ||
+                    line.contains('Core Nextflow options') ||
+                    line.contains('runName') ||
+                    line.contains('launchDir') ||
+                    line.contains('workDir') ||
+                    line.contains('projectDir') ||
+                    line.contains('userName') ||
+                    line.contains('profile') ||
+                    line.contains('configFiles') ||
+                    line.contains('outdir ')
+                    ? line : null
+                }
+
+        then:
+        noExceptionThrown()
+        stdout.size() == 9
+        stdout != ~ /.*outdir     : \\/mask\\/outDir.*/
+    }
+
 }


### PR DESCRIPTION
Mask `/fusion`, `/s3/bucket/`, `s3://bucket/` and arbitrary subpaths from path values in summary messages.

For our use case, we want to distribute `multiqc_report.html` files without leaking details of our infrastructure.

nextflow.config:
```
validation {
    summary {
        maskBucketNames = true
    }
}
```

```bash
$ nextflow run -profile test,docker main.nf --outdir test

 N E X T F L O W   ~  version 25.10.3

Launching `main.nf` [grave_gutenberg] DSL2 - revision: 338ee9742e


------------------------------------------------------
                                        ,--./,-.
        ___     __   __   __   ___     /,-._.--~'
  |\ | |__  __ /  ` /  \ |__) |__         }  {
  | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                        `._,._,'
      ____
    .´ _  `.
   /  |\`-_ \      __        __   ___
  |   | \  `-|    |__`  /\  |__) |__  |__/
   \ |   \  /     .__| /¯¯\ |  \ |___ |  \
    `|____\´

  nf-core/sarek 3.8.0
------------------------------------------------------

...
Reference genome options
  sentieon_dnascope_model   : [** masked **]/igenomes/Homo_sapiens/GATK/GRCh38/Annotation/Sentieon/SentieonDNAscopeModel1.1.model
```