### PR TITLE
Improve type cast handling for syntax parser v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         java_version: [17, 21, 25]
-        syntax_parser_version: [1, 2]
 
     steps:
       - name: Environment
@@ -42,7 +41,7 @@ jobs:
         run: ./gradlew assemble
 
       - name: Tests
-        run: NXF_SYNTAX_PARSER=v${{ matrix.syntax_parser_version }} ./gradlew check
+        run: ./gradlew check
         env:
           GRADLE_OPTS: '-Dorg.gradle.daemon=false'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: [17, 21, 25]
+        syntax_parser_version: [1, 2]
 
     steps:
       - name: Environment
@@ -41,7 +42,7 @@ jobs:
         run: ./gradlew assemble
 
       - name: Tests
-        run: ./gradlew check
+        run: NXF_SYNTAX_PARSER=v${{ matrix.syntax_parser_version }} ./gradlew check
         env:
           GRADLE_OPTS: '-Dorg.gradle.daemon=false'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # nextflow-io/nf-schema: Changelog
 
+# Version 2.7.2
+
+## New features
+
+1. Added a new option to `validateParameters()`: `cast_cli_params`. This option takes a boolean value and determines whether or not parameters provided via the CLI should be cast to their respective types based on the JSON schema. The default value is `true` if the syntax parser version is 2 and `false` otherwise.
+
+## Changes
+
+1. Type casting of parameters is now restricted to only parameters provided via the CLI. This should mimic the behaviour of syntax parser V1 until static typing is introduced in Nextflow
+
 # Version 2.7.1
 
 ## Bug fixes

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Declare the plugin in your Nextflow pipeline configuration file:
 
 ```groovy title="nextflow.config"
 plugins {
-  id 'nf-schema@2.7.1'
+  id 'nf-schema@2.7.2'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.0'
 }
 
-version = '2.7.1'
+version = '2.7.2'
 
 nextflowPlugin {
     nextflowVersion = '25.10.0'

--- a/docs/parameters/validation.md
+++ b/docs/parameters/validation.md
@@ -13,15 +13,16 @@ This function takes all pipeline parameters and checks that they adhere to the s
 - If any parameter validation has failed, it throws a `SchemaValidationException` exception to stop the pipeline.
 - If any parameters in the schema reference a sample sheet schema with `schema`, that file is loaded and validated.
 
-The function takes two optional arguments:
+The function takes three optional arguments:
 
 - The filename of a JSON Schema file (optional, default: `nextflow_schema.json`). File paths should be relative to the root of the pipeline directory.
 - A boolean to disable coloured outputs (optional, default: `false`). The output is coloured using ANSI escape codes by default.
+- A boolean to enable or disable type casting of parameters provided via the CLI (optional, default: `true` if the syntax parser version is 2 and `false` otherwise).
 
-You can provide the parameters as follows:
+You can provide the arguments as follows:
 
 ```nextflow
-validateParameters(parameters_schema: 'custom_nextflow_parameters.json', monochrome_logs: true)
+validateParameters(parameters_schema: 'custom_nextflow_parameters.json', monochrome_logs: true, cast_cli_params: true)
 ```
 
 Monochrome logs can also be set globally providing the parameter `--monochrome_logs` or adding `params.monochrome_logs = true` to a configuration file. The form `--monochromeLogs` is also supported.

--- a/examples/helpMessage/pipeline/nextflow.config
+++ b/examples/helpMessage/pipeline/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-schema@2.7.1'
+  id 'nf-schema@2.7.2'
 }
 
 params {

--- a/examples/paramsHelp/pipeline/nextflow.config
+++ b/examples/paramsHelp/pipeline/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-schema@2.7.1'
+  id 'nf-schema@2.7.2'
 }
 
 params {

--- a/examples/paramsSummaryLog/pipeline/nextflow.config
+++ b/examples/paramsSummaryLog/pipeline/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-schema@2.7.1'
+  id 'nf-schema@2.7.2'
 }
 
 params {

--- a/examples/paramsSummaryMap/pipeline/nextflow.config
+++ b/examples/paramsSummaryMap/pipeline/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-schema@2.7.1'
+  id 'nf-schema@2.7.2'
 }
 
 params {

--- a/examples/samplesheetToListBasic/pipeline/nextflow.config
+++ b/examples/samplesheetToListBasic/pipeline/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-schema@2.7.1'
+  id 'nf-schema@2.7.2'
 }
 
 params {

--- a/examples/samplesheetToListMeta/pipeline/nextflow.config
+++ b/examples/samplesheetToListMeta/pipeline/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-schema@2.7.1'
+  id 'nf-schema@2.7.2'
 }
 
 params {

--- a/examples/samplesheetToListOrder/pipeline/nextflow.config
+++ b/examples/samplesheetToListOrder/pipeline/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-schema@2.7.1'
+  id 'nf-schema@2.7.2'
 }
 
 params {

--- a/examples/validateParameters/pipeline/nextflow.config
+++ b/examples/validateParameters/pipeline/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-schema@2.7.1'
+  id 'nf-schema@2.7.2'
 }
 
 params {

--- a/examples/validationFailUnrecognisedParams/pipeline/nextflow.config
+++ b/examples/validationFailUnrecognisedParams/pipeline/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-schema@2.7.1'
+  id 'nf-schema@2.7.2'
 }
 
 validation.logging.unrecognisedParams = "error"

--- a/examples/validationWarnUnrecognisedParams/pipeline/nextflow.config
+++ b/examples/validationWarnUnrecognisedParams/pipeline/nextflow.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-schema@2.7.1'
+  id 'nf-schema@2.7.2'
 }
 
 params {

--- a/src/main/groovy/nextflow/validation/ValidationExtension.groovy
+++ b/src/main/groovy/nextflow/validation/ValidationExtension.groovy
@@ -88,13 +88,12 @@ class ValidationExtension extends PluginExtensionPoint {
     */
     @Function
     void validateParameters(
-        Map options = null
+        final Map options = [:]
     ) {
         ParameterValidator validator = new ParameterValidator(config)
         validator.validateParametersMap(
             options,
-            session.params,
-            session.baseDir.toString()
+            session
         )
     }
 

--- a/src/main/groovy/nextflow/validation/parameters/ParameterValidator.groovy
+++ b/src/main/groovy/nextflow/validation/parameters/ParameterValidator.groovy
@@ -12,6 +12,7 @@ import groovy.json.JsonGenerator
 import groovy.util.logging.Slf4j
 import groovy.transform.CompileDynamic
 import nextflow.Nextflow
+import nextflow.Session
 import nextflow.util.Duration
 import nextflow.util.MemoryUnit
 import nextflow.util.VersionNumber
@@ -120,14 +121,17 @@ class ParameterValidator {
     final private List<String> warnings = []
 
     void validateParametersMap(
-        Map options = null,
-        Map inputParams = [:],
-        String baseDir
+        final Map options = [:],
+        Session session
     ) {
-        Map<String, Object> params = initialiseExpectedParams(inputParams)
+        Map<String, Object> params = initialiseExpectedParams(session.params)
         String schemaFilename = options?.containsKey('parameters_schema') ?
             options.parameters_schema as String :
             config.parametersSchema
+        Boolean castCliParams = options?.containsKey('cast_cli_params') ?
+            options.cast_cli_params as Boolean :
+            /* groovylint-disable-next-line UnnecessaryGetter */
+            isSyntaxParserV2()
         log.debug 'Starting parameters validation'
 
         // Convert to JSONObject
@@ -138,10 +142,18 @@ class ParameterValidator {
             .addConverter(MemoryUnit) { MemoryUnit memory -> memory.toBytes() }
             .addConverter(VersionNumber) { VersionNumber version -> version.toString() }
 
-        // Explicitly cast parameters to the expected values when strict syntax is used
-        /* groovylint-disable-next-line UnnecessaryGetter */
-        if (isSyntaxParserV2()) {
-            generatorOptions.addConverter(String) { String str -> parseParamValue(str) }
+        // Cast parameters provided via the CLI to their respective types.
+        // This is a temporary workaround until static typing is introduced in Nextflow,
+        // in which case we can rely on the static type system to do the casting for us.
+        // This mimics the type casting behaviour of syntax parser V1 so shouldn't introduce any breaking changes.
+        if (castCliParams) {
+            List<String> cliParams = session.cliParams.keySet().toList()
+            generatorOptions.addConverter(Map<String, Object>) { Map<String,Object> map ->
+                map.collectEntries { k, v ->
+                    // Only cast parameters that were explicitly provided via the CLI
+                    return (cliParams.contains(k) && v in String) ? [k, parseParamValue(v)] : [k, v]
+                }
+            }
         }
 
         JSONObject paramsJSON = new JSONObject(generatorOptions.build().toJson(params))
@@ -153,6 +165,7 @@ class ParameterValidator {
         Map<String,String> colors = getLogColors(config.monochromeLogs)
 
         // Validate
+        String baseDir = session.baseDir
         ValidationResult validationResult = validator.validate(paramsJSON, getBasePath(baseDir, schemaFilename))
         List<String> paramErrors = validationResult.getErrors('parameter')
         errors.addAll(paramErrors)

--- a/src/main/groovy/nextflow/validation/parameters/ParameterValidator.groovy
+++ b/src/main/groovy/nextflow/validation/parameters/ParameterValidator.groovy
@@ -147,7 +147,7 @@ class ParameterValidator {
         // in which case we can rely on the static type system to do the casting for us.
         // This mimics the type casting behaviour of syntax parser V1 so shouldn't introduce any breaking changes.
         if (castCliParams) {
-            List<String> cliParams = session.cliParams.keySet().toList()
+            List<String> cliParams = session.cliParams?.keySet()?.toList() ?: []
             generatorOptions.addConverter(Map<String, Object>) { Map<String,Object> map ->
                 map.collectEntries { k, v ->
                     // Only cast parameters that were explicitly provided via the CLI


### PR DESCRIPTION
- Added a new `cast_cli_params` option to the `validateParameters()` function, allowing users to control whether CLI-provided parameters are cast to their suspected type. The default is `true` for syntax parser version 2, `false` otherwise. Type casting is now strictly limited to CLI parameters, mimicking syntax parser V1 behavior until static typing is available in Nextflow.
- Modified the GitHub Actions build workflow to test across multiple `syntax_parser_version` values, and to pass the selected version to the test runner via the `NXF_SYNTAX_PARSER` environment variable.