### PR TITLE
Only build docs on release

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,10 +1,6 @@
 name: build docs
 on:
-  push:
-    branches:
-      - master
-      - main
-      - dev
+  release:
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
This pull request updates the documentation build workflow to trigger only on new releases, rather than on every push to certain branches. This change helps reduce unnecessary documentation builds and ensures that docs are built only for official releases.

Workflow trigger update:

* [`.github/workflows/build-docs.yml`](diffhunk://#diff-4fdc48ab490b670c90974725b8e3d399b24c03d6d09563acf8ea87d4113930fbL3-R3): Changed the workflow trigger from `push` events on `master`, `main`, and `dev` branches to only trigger on `release` events.